### PR TITLE
Update manual.html - removes (inexistant) DE manual link

### DIFF
--- a/manual.html
+++ b/manual.html
@@ -26,11 +26,6 @@
 		</tr>
 		<tr>
 			<td>
-				<li><a href="manual_de.html">Deutsche Anleitung</a>
-			</td>
-		</tr>
-		<tr>
-			<td>
 				<li><a href="manual_fr.html">French manual</a>
 			</td>
 		</tr>


### PR DESCRIPTION
There is no DE manual, then when : _Hydrogen menu -> Info -> User manual_ and clicking on "Deutsche Anleitung", we are flicked to a blank page. This is confusing. Let's remove it.