### PR TITLE
Restructuring

### DIFF
--- a/manual.docbook
+++ b/manual.docbook
@@ -55,8 +55,6 @@
       </para>
     </chapter>
 
-<!-- COMPILATION  -->
-
     <chapter id="chpt.compilation">
       <title>Build</title>
 
@@ -180,7 +178,6 @@
         </note>
     </chapter>
 
-<!--   KEYBOARD AND MOUSE -->
     <chapter id="chpt.keyboard_and_mouse">
       <title>Keyboard and Mouse</title>
       <para>
@@ -264,16 +261,9 @@
 
 </part>
 
-  <!--
-      ####################
-      # SECOND CHAPTER   #
-      ####################
-  -->
-
-  <part id="part.using_hydrogen">
+<part id="part.using_hydrogen">
     <title>Using Hydrogen</title>
 
-<!--   UI OVERVIEW  -->
     <chapter id="chpt.UIoverview">
       <title>Overview</title>
       
@@ -287,13 +277,20 @@
         </mediaobject>
       </figure>
 
+      <para>
+	    TODO: update image (and adding the gimp session as well in order for future maintainance to only replace the background image
+      </para>
+
       <para>The Main UI comes in 2 flavors : the (classic) Single Pane mode (ideal for
       large- and medium size screens), and the Tabbed mode (optimized for netbook screen 
       sizes).
       </para>
       <para>
-      Below you can see the main UI split up in 5 parts : the Main Menu, Main 
-      Toolbar, Song Editor, Pattern Editor and the Instrument and Sound Library Editor.
+	    TODO: mention and link corresponding option in Preferences > Appearance
+      </para>
+      <para>
+      Below you can see the main UI split up in 5 parts: the <link linkend="chpt.main_menu">Main Menu</link>, <link linkend="chpt.main_toolbar">Main 
+      Toolbar</link>, <link linkend="chpt.song_editor">Song Editor</link>, <link linkend="chpt.pattern_editor">Pattern Editor</link> and the <link linkend="chpt.instrument_editor">Instrument</link> and <link linkend="chpt.sound_library">Sound Library Editor</link>.
         These sections will be explained in detail further down in this
         manual.
       </para>
@@ -313,9 +310,7 @@
     <chapter id="chpt.preferences" xreflabel="Preferences">
       <title>Preferences</title>
 
-      <para>First of all you should make sure that the audio engine is
-      configured properly.  The preferences dialog can be accessed via the tools
-      menu (tools -&gt; preferences).</para>
+      <para>Via this window most of the configurations and customization can be altered. The Preferences Dialog can be accessed via the <parameter>Options</parameter> element in the <link linkend="chpt.main_menu">Main Menu</link>.</para>
 
       <sect1 id="chpt.preferences.general_tab">
         <title>General</title>
@@ -328,6 +323,10 @@
             </imageobject>
           </mediaobject>
         </figure>
+
+        <para>
+	      TODO: update image, options, and description. Convert the layout of the section to a item list similar to the other ones.
+        </para>
         
         <para>On the "General" tab (<xref linkend="fig.preferences.general_tab"/>) you can 
         choose to automatically reopen the last used song and/or playlist.  This can save you 
@@ -357,6 +356,10 @@
           </mediaobject>
         </figure>
 
+        <para>
+	      TODO: update image, options, and description
+        </para>
+        
         <para>From the "Audio System" tab (<xref
         linkend="fig.preferences.audio_tab"/>) it is possible to modify the
         audio driver being used (<abbrev>OSS</abbrev>, <abbrev>JACK</abbrev>, <abbrev>ALSA</abbrev>, PortAudio, PulseAudio, CoreAudio, Auto) with its buffer and
@@ -493,6 +496,10 @@
           </mediaobject>
         </figure>
 
+        <para>
+	      TODO: update image, options, and description
+        </para>
+
         <para>The "MIDI System" tab (<xref linkend="fig.preferences.midi_tab"/>)
         contains all <abbrev>MIDI</abbrev> settings. Here you can choose the <abbrev>MIDI</abbrev> driver (<abbrev>ALSA</abbrev>, PortMidi, 
         CoreMidi or JackMidi) input, and channel(s) that Hydrogen should respond to.  
@@ -595,6 +602,10 @@
           </mediaobject>
         </figure>
 
+        <para>
+	      TODO: update image, options, and description
+        </para>
+
         <para>The "Appearance" tab (<xref
         linkend="fig.preferences.appearance_tab"/>) let's you modify Hydrogen look 
         and feel (font settings and interface style). On this tab you can also change the 
@@ -605,9 +616,12 @@
 
     </chapter>
     
-<!--  MAIN MENU -->
     <chapter id="chpt.main_menu">
       <title>Main Menu</title>
+
+      <para>
+	    TODO: add picture of the main menu
+      </para>
 
       <sect1 id="sect.main_menu.projects">
         <title>Projects</title>
@@ -616,64 +630,65 @@
 
         <itemizedlist>
           <listitem>
-            <para><emphasis role="bold">New</emphasis>: create a new song</para>
+            <para><emphasis role="bold">New</emphasis>: creates a new song.</para>
           </listitem>
           <listitem>
-            <para><emphasis role="bold">Show Info</emphasis>: set general properties of the
-            song such as name, author, license and generic notes</para>
+            <para><emphasis role="bold">Show Info</emphasis>: sets general properties of the
+            song such as name, author, license and generic notes.</para>
           </listitem>
           <listitem>
-            <para><emphasis role="bold">Open</emphasis>: open a song</para>
+            <para><emphasis role="bold">Open</emphasis>: opens a song.</para>
           </listitem>
           <listitem>
-            <para><emphasis role="bold">Open Demo</emphasis>: open a demo song (demo songs
+            <para><emphasis role="bold">Open Demo</emphasis>: opens a demo song (demo songs
             are stored in
-            <emphasis>$INSTALLPATH/share/hydrogen/data/demo_songs</emphasis>)</para>
+            <filename>$INSTALL_PATH/share/hydrogen/data/demo_songs</filename>).</para>
           </listitem>
           <listitem>
-            <para><emphasis role="bold">Open recent</emphasis>: open a menu showing last used
-            songs</para>
+            <para><emphasis role="bold">Open recent</emphasis>: opens a menu showing last used
+            songs.</para>
           </listitem>
           <listitem>
-            <para><emphasis role="bold">Save</emphasis>: save changes to current song</para>
+            <para><emphasis role="bold">Save</emphasis>: saves changes to current song.</para>
           </listitem>
           <listitem>
-            <para><emphasis role="bold">Save as</emphasis>: save current song specifying a
+            <para><emphasis role="bold">Save as</emphasis>: saves current song specifying a
             name (default path:
-            <emphasis>$HOME/.hydrogen/data/songs)</emphasis></para>
+            <filename>$HOME/.hydrogen/data/songs/)</filename>.</para>
           </listitem>
           <listitem>
-            <para><emphasis role="bold">Open pattern</emphasis>: open a saved pattern
-            belonging to the current drumkit</para>
+            <para><emphasis role="bold">Open pattern</emphasis>: opens a saved pattern
+            belonging to the current drumkit.</para>
           </listitem>
           <listitem>
             <para><emphasis role="bold">Export pattern as</emphasis>: saves a
-            pattern. It will be stored in
-            <emphasis>$HOME/.hydrogen/data/patterns/drumkit_name</emphasis></para>
+            pattern. In order for Hydrogen to automatically list it in the <link linkend="sect.sl.patterns">Patterns section of the Sound Library</link> you have to store it in
+            <filename>$HOME/.hydrogen/data/patterns/drumkit_name/</filename></para>
           </listitem>
           <listitem>
-            <para><emphasis role="bold">Export MIDI file</emphasis>: export current song in
-            <abbrev>MIDI</abbrev> format</para>
+            <para><emphasis role="bold">Export MIDI file</emphasis>: exports the current song in
+            <abbrev>MIDI</abbrev> format.</para>
           </listitem>
           <listitem id="sect.main_form.export_song" xreflabel="Export Song">
-            <para><emphasis role="bold">Export song</emphasis>: export current song in WAV
+            <para><emphasis role="bold">Export song</emphasis>: exports the current song in WAV
             format.</para>
+            
+            <figure id="fig.Export_song">
+              <title>Export a Song</title>
+              <mediaobject>
+                <imageobject>
+                  <imagedata fileref="img/Export_song.png" format="PNG" />
+                </imageobject>
+              </mediaobject>
+            </figure>
+
+            <para>
+	          TODO: update image and describe new and old options (in an itemized list instead of a procedural guide)
+            </para>
             
             <para>Once your song is finished you can export it to an audio file.
             This audio file can then be played on your favorite media player or imported
-            in an other audio application.</para>
-            <para>
-              To do this, go to Project - "Export song" and the following window will pop up:
-              <figure id="fig.Export_song">
-                <title>Export a Song</title>
-                <mediaobject>
-                  <imageobject>
-                    <imagedata fileref="img/Export_song.png" format="PNG" />
-                  </imageobject>
-                </mediaobject>
-              </figure>
-              To export a song you need to do 3 things:
-              
+            in an other audio application. To export a song you need to do 3 things:
             </para>
             
             <procedure>
@@ -717,18 +732,21 @@
                 As a workaround you can record the output of Hydrogen with an audio recording
                 application (like Ardour, Qtractor ...)
               </para>
+              <para>
+	            TODO: is this still valid?
+              </para>
             </note>
 
-            <para>
-	          TODO: fuse
-            </para>
           </listitem>
           <listitem>
-            <para><emphasis role="bold">Export Lilypond file</emphasis>: this is a first version of the LilyPond export.
-            It has the following limitations: Only GM-kit is supported, No triplets support</para>
+            <para><emphasis role="bold">Export Lilypond file</emphasis>: exports the current song to LilyPond.</para>
+            <warning>
+	          <para>
+            It has the following limitations: Only the <emphasis>GMRockKit</emphasis> and no triplets are supported.</para>
+            </warning>
           </listitem>
           <listitem>
-            <para><emphasis role="bold">Quit</emphasis>: quit Hydrogen</para>
+            <para><emphasis role="bold">Quit</emphasis>: exists Hydrogen.</para>
           </listitem>
         </itemizedlist>
       </sect1>
@@ -739,50 +757,23 @@
         
         <itemizedlist>
           <listitem>
-            <para><emphasis role="bold">Undo</emphasis>: lets you undo your last action</para>
+            <para><emphasis role="bold">Undo</emphasis>: lets you undo your last action.</para>
           </listitem>
           <listitem>
-            <para><emphasis role="bold">Redo</emphasis>: lets you redo the last undone action</para>
+            <para><emphasis role="bold">Redo</emphasis>: lets you redo the last undone action.</para>
           </listitem>
           <listitem>
             <para><emphasis role="bold">Undo History</emphasis>: gives you an overview of your previous
-            actions</para>
+            actions.</para>
           </listitem>
         </itemizedlist>
       </sect1>
-
-      <sect1 id="sect.main_menu.instruments">
-        <title>Instruments</title>
-        <para>This menu offers
-        instruments functions.</para>
-
-        <itemizedlist>
-          <listitem>
-            <para><emphasis role="bold">Add instrument</emphasis>: add a new instrument to your current drumkit</para>
-          </listitem>
-          <listitem>
-            <para><emphasis role="bold">Clear all</emphasis>: delete all instruments from the current drumkit</para>
-          </listitem>
-          <listitem>       
-            <para><emphasis role="bold">Add component</emphasis>: a component is a part of Hydrogen's instrument model.
-            Each instrument consists of one or more components, and each component consists of one or more layers.
-            </para>
-
-            <para>To make an example: A snare could have two components.
-            One component includes sounds from the top side of the snare drum, and the other component includes
-            the sounds from the bottom side of the snare drum (where the snare wires are fitted).
-            Each component can consist of several layers (snare drum hits with different velocities).
-            Now you can adjust the volume of the two components to build your ideal drum sound.
-            If you want more of the attack, you can put in more of the "top head" component.
-            If you want more of the snare wires, you put in more of the bottom component.
-            </para>
-          </listitem>
-        </itemizedlist>
-      </sect1>
-
       <sect1 id="sect.main_menu.drumkits">
         <title>Drumkits</title>
         <para>This menu offers drumkit (sound libraries) functions.</para>
+        <para>
+	      TODO: update item list
+        </para>
         <itemizedlist>
           <listitem>
             <para><emphasis role="bold">Save</emphasis>: saves all instruments settings (and their sound samples) in
@@ -829,54 +820,62 @@
         </itemizedlist>
       </sect1>
 
-      <sect1 id="sect.main_menu.view">
-        <title>View</title>
-        <para>Opens the director, the playlist editor, the instrument rack
-        and the general preferences window.
-        </para>
+      <sect1 id="sect.main_menu.instruments">
+        <title>Instruments</title>
+        <para>This menu offers
+        instruments functions.</para>
 
         <itemizedlist>
           <listitem>
-            <para><emphasis role="bold">Playlist editor</emphasis>: a tool to manage
-            playlists.</para>
+            <para><emphasis role="bold">Add Instrument</emphasis>: adda a new instrument to your current drumkit.</para>
           </listitem>
           <listitem>
-            <para><emphasis role="bold">Director</emphasis>: open the director window.</para>
+            <para><emphasis role="bold">Clear All</emphasis>: deletes all instruments from the current drumkit.</para>
+          </listitem>
+          <listitem>       
+            <para><emphasis role="bold">Add Component</emphasis>: adds a <link linkend="def.component">component</link> to the current drumkit.</para>
+          </listitem>
+        </itemizedlist>
+      </sect1>
+
+      <sect1 id="sect.main_menu.view">
+        <title>View</title>
+
+        <itemizedlist>
+          <listitem>
+            <para><emphasis role="bold">Playlist Editor</emphasis>: opens the <link linkend="chpt.playlist_editor">Playlist Editor</link> window.</para>
           </listitem>
           <listitem>
-            <para><emphasis role="bold">Mixer</emphasis>: open the mixer window.</para>
+            <para><emphasis role="bold">Director</emphasis>: opens the <link linkend="chpt.director">Director</link> window.</para>
           </listitem>
           <listitem>
-            <para><emphasis role="bold">Instrument rack</emphasis>: open the instrument rack
+            <para><emphasis role="bold">Mixer</emphasis>: opens the <link linkend="chpt.mixer">Mixer</link> window.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis role="bold">Instrument Rack</emphasis>: shows or hides the widget of the main window containing both the <link linkend="chpt.instrument_editor">Instrument Editor</link> and the <link linkend="chpt.sound_library">Sound Library</link>.</para>
+          </listitem>
+          <listitem>
+            <para><emphasis role="bold">Automation Path</emphasis>: shows or hides the <link linkend="sect.song_editor.automation_path">Automation Path</link>
             panel.</para>
           </listitem>
           <listitem>
-            <para><emphasis role="bold">Automation path</emphasis>: open the automation path
-            panel.</para>
+            <para><emphasis role="bold">Timeline</emphasis>: shows or hides the <link linkend="chpt.song_editor.timeline">Timeline</link> panel.</para>
           </listitem>
           <listitem>
-            <para><emphasis role="bold">Timeline</emphasis>: open the time line
-            panel (auto hiding the playback track)</para>
+            <para><emphasis role="bold">Playback Track</emphasis>: shows or hides the <link linkend="chpt.song_editor.playbackTrack">Playback Track</link> panel.</para>
           </listitem>
           <listitem>
-            <para><emphasis role="bold">Playback track</emphasis>: open the time line
-            panel (auto hiding the timeline)</para>
-          </listitem>
-          <listitem>
-            <para><emphasis role="bold">Full screen</emphasis>: maximises the window size to the whole screen area</para>
+            <para><emphasis role="bold">Full screen</emphasis>: maximises the window size to the whole screen area.</para>
           </listitem>
         </itemizedlist>
       </sect1>
 
       <sect1 id="sect.main_menu.options">
         <title>Options</title>
-        <para>Selects the input mode and opens the general preferences
-        window.</para>
-
         <itemizedlist>
           <listitem>
-            <para><emphasis role="bold">Input mode</emphasis>: when set to <emphasis>Drumset</emphasis> the keys on your midi keyboard will map to the instruments
-            in your drumkit. If you set it to <emphasis>Instrument</emphasis> the keys of your midi 
+            <para><emphasis role="bold">Input mode</emphasis>: when set to <emphasis>Drumset</emphasis> the keys on your <abbrev>MIDI</abbrev> keyboard will map to the instruments
+            in your drumkit. If you set it to <emphasis>Instrument</emphasis> the keys of your <abbrev>MIDI</abbrev>
             keyboard will trigger the instrument that is currently selected.
             The pitch of the instrument will follow the key you press on your keyboard.
             This feature is mainly used for non-drum instruments.
@@ -885,15 +884,19 @@
           </listitem>
           
           <listitem>
-            <para><emphasis role="bold">Preferences</emphasis>: open the main preferences
-            window. Read <xref linkend="chpt.preferences"/> on how to configure
-            Hydrogen.</para>
+            <para><emphasis role="bold">Preferences</emphasis>: opens the main preferences
+            window (see <xref linkend="chpt.preferences"/> for details).</para>
           </listitem>
         </itemizedlist>
       </sect1>
 
       <sect1 id="sect.main_menu.debug">
         <title>Debug</title>
+
+        <para>
+	      TODO: update option list and description
+        </para>
+        
         <para>Tools mainly for debugging
         and monitoring Hydrogen (only available when compiled with debug
         support !).</para>
@@ -940,7 +943,7 @@
 
         <itemizedlist>
           <listitem>
-            <para><emphasis role="bold">User manual</emphasis>: open a window with this
+            <para><emphasis role="bold">User manual</emphasis>: opens a window with this
             manual :)</para>
           </listitem>
           <listitem>
@@ -948,11 +951,11 @@
             information, acknowledgments, etc.</para>
           </listitem>
           <listitem>
-            <para><emphasis role="bold">Report bug</emphasis>: opens the Hydrogen issue page at github.com in Internet browser
-            You can open a new issue to communicate a bug here (first search if there exists already an issue about it)</para>
+            <para><emphasis role="bold">Report bug</emphasis>: opens the <ulink url="https://github.com/hydrogen-music/hydrogen/issues">Hydrogen issue page at github.com</ulink> in your default Internet browser.
+            You can open a new issue to communicate a bug here (first search if there exists already an issue about it).</para>
           </listitem>
           <listitem>
-            <para><emphasis role="bold">Donate</emphasis>: make a donation to developers/mantainers</para>
+            <para><emphasis role="bold">Donate</emphasis>: make a donation to developers/mantainers.</para>
           </listitem>
         </itemizedlist>
       </sect1>
@@ -2187,14 +2190,14 @@
       </sect1>
     </chapter>
 
-    <chapter id="chpt.instrument_editing">
-      <title>Instrument and Drumkits Editor</title>
+    <chapter id="chpt.instrument_editor">
+      <title>Instrument Editor</title>
 
       <para>
 	    TODO: disentangle this chapter into a plain description of the "General" and "Layers" view of the Instrument Editor and split of the "Create a New Drumkit" tutorial and put it in the examples
       </para>
 
-      <sect1 id="chpt.instrument_editing.concepts">
+      <sect1 id="chpt.instrument_editor.concepts">
         <title>Concepts</title>
 
         <para>
@@ -2340,10 +2343,10 @@
         </itemizedlist>
 
         <para>It's important that you understand <xref
-        linkend="chpt.instrument_editing.concepts"/> in order to continue
+        linkend="chpt.instrument_editor.concepts"/> in order to continue
         on.</para>
 
-        <sect2 id="chpt.instrument_editing.envelope_parameters">
+        <sect2 id="chpt.instrument_editor.envelope_parameters">
           <title>Envelope Parameters</title>
 
           <para>When the instrument is triggered, its volume is run through an
@@ -2400,7 +2403,7 @@
 
         </sect2>
 
-        <sect2 id="chpt.instrument_editing.gain_and_mute_group">
+        <sect2 id="chpt.instrument_editor.gain_and_mute_group">
           <title>Gain and Mute Group</title>
 
           <para>The gain sets the overall volume for the sample.  This gain is
@@ -2436,7 +2439,7 @@
           to 2.)</para>
         </sect2>
         
-        <sect2 id="chpt.instrument_editing.auto_stop_note">
+        <sect2 id="chpt.instrument_editor.auto_stop_note">
           <title>Auto Stop-Note</title>
 
           <para>If this box is checked Hydrogen will immediately stop any playing sample that
@@ -2451,7 +2454,7 @@
 
           </para>
         </sect2>
-        <sect2 id="chpt.instrument_editing.apply_velocity">
+        <sect2 id="chpt.instrument_editor.apply_velocity">
           <title>Apply Velocity</title>
           <para>
              This lets the user decide if Hydrogen will apply the note velocity to the sample being played.
@@ -2469,7 +2472,7 @@
           </para>
         </sect2>  
 
-        <sect2 id="chpt.instrument_editing.filter">
+        <sect2 id="chpt.instrument_editor.filter">
           <title>Filter Parameters</title>
 
           <para>The filter is a low-pass resonance filter.  If you don't wish to
@@ -2500,7 +2503,7 @@
           </note>
         </sect2>
         
-        <sect2 id="chpt.instrument_editing.pitch_shift_parameters">
+        <sect2 id="chpt.instrument_editor.pitch_shift_parameters">
           <title>Pitch Shift Parameters</title>
           <para> The first two knobs control the pitch shift offset.
                  You can use it to change the tuning of the instrument.
@@ -2516,7 +2519,7 @@
         </sect2>   
         
 
-        <sect2 id="chpt.instrument_editing.midi_out_settings">
+        <sect2 id="chpt.instrument_editor.midi_out_settings">
           <title>MIDI Out Settings</title>
 
           <para>Hydrogen is capable of generating midi messages that you can use
@@ -2534,7 +2537,7 @@
           internal Hydrogen sampler with multiple external apps/devices.</para>
 
         </sect2>
-        <sect2 id="chpt.instrument_editing.HH_pressure_group">
+        <sect2 id="chpt.instrument_editor.HH_pressure_group">
           <title>Hi-Hat Pressure Group</title>
             <para>The Hi-Hat is a particular instrument of the drumkit as its sound can be changed by pressing the foot pedal.
             </para>
@@ -4109,7 +4112,7 @@
 	 <title>Create a New Drumkit</title>
      <para>TODO: make consistent</para>
      
-      <sect1 id="chpt.instrument_editing.new_kit">
+      <sect1 id="chpt.instrument_editor.new_kit">
        <title>Creating a New Drumkit</title>
        <para>In the next paragraphs we will show you how to create a complete drumkit.  
        Keeping in mind the 'Soundlibrary hierarchy' (see <xref linkend="fig.SoundlibraryHierarchy"/>)
@@ -4187,7 +4190,7 @@
 
       </sect1>
 
-      <sect1 id="chpt.instrument_editing.tips">
+      <sect1 id="chpt.instrument_editor.tips">
         <title>Tips on Editing Instruments</title>
 
         <para>With all of the different parameters available to tweak, it can be
@@ -4524,6 +4527,24 @@
       </glossdef>
     </glossentry>
 
+    <glossentry id="def.component">
+	  <glossterm>Component</glossterm>
+      <glossdef>
+	    <para>
+	      A component is a part of Hydrogen's instrument model.
+          Each instrument consists of one or more components, and each component consists of one or more layers.
+        </para>
+
+        <para>To make an example: A snare could have two components.
+        One component includes sounds from the top side of the snare drum, and the other component includes
+        the sounds from the bottom side of the snare drum (where the snare wires are fitted).
+        Each component can consist of several layers (snare drum hits with different velocities).
+        Now you can adjust the volume of the two components to build your ideal drum sound.
+        If you want more of the attack, you can put in more of the "top head" component.
+        If you want more of the snare wires, you put in more of the bottom component.
+        </para>
+      </glossdef>
+    </glossentry>
     <glossentry id="def.cutoff">
       <glossterm>Cutoff Frequency</glossterm>
       <glossdef>

--- a/manual.docbook
+++ b/manual.docbook
@@ -1360,19 +1360,17 @@
           </para>
         </listitem>
 
-        <listitem>
+        <listitem id="chpt.song_editor.main_controls.single_vs_stacked" xreflabel="Single Pattern and Stacked Pattern Mode">
           <para><inlinemediaobject><imageobject>
             <imagedata fileref="img/btn_pattern_mode.png" format="PNG"/>
-            </imageobject></inlinemediaobject> set Hydrogen to "Single pattern mode"
+            </imageobject></inlinemediaobject> : sets Hydrogen to <emphasis>Single Pattern Mode</emphasis> 
             <inlinemediaobject><imageobject>
             <imagedata fileref="img/stacked_mode_V3.png" format="PNG"/>
             </imageobject></inlinemediaobject>
-            or to "Stacked pattern mode".</para>
-            <para>For more info on this see the SELECT_NEXT_PATTERN midi action in <xref linkend="chpt.midi"/>.
-            </para>
+            or to <emphasis>Stacked Pattern Mode</emphasis>.</para>
 
             <para>
-	          TODO: move description in here.
+	          TODO: add a description of these two modes (maybe as subsections next to the Pattern and Song Mode)
             </para>
         </listitem>
       </itemizedlist>
@@ -1651,92 +1649,106 @@
            </imageobject>
          </mediaobject>
         </figure>
-      <para>The "Pattern Editor" 
-      allows you to create or modify the selected pattern by adding/removing notes and tuning 
+
+        <para>
+	      TODO: update image. the 'RES' display has changed.
+        </para>
+        
+        <para>This is where it all happens, this is where you can make music :-)</para>
+        
+      <para>The <emphasis>Pattern Editor</emphasis>
+      allows you to create and modify the selected pattern by adding/removing notes and tuning 
       a number of per-note properties like velocity and pan.
       The Pattern Editor 
-      can be used in 2 modes : 'Drum' mode or 'Piano' mode.  You can switch between these 
-      modes by clicking the Drum/Piano button (located on the top-right of the Pattern Editor) 
-      <note>
-      <itemizedlist mark="opencircle">
-      <listitem><para>
-      If you are editing a pattern in Single Pattern Mode you will always hear the pattern you are 
-      editing when you press play.</para></listitem>
-      <listitem><para>If you are working in Stacked Pattern Mode you will hear the <emphasis>active</emphasis> pattern(s), 
-      not necessarily the pattern you are currently editing.
-      (The active patterns have a small triangle next to the pattern name in the Song Editor). 
-      </para></listitem>
-      </itemizedlist>
-      </note>
-      
+      can be used in 2 modes : as <link linkend="chpt.pattern_editor.drumkit">Drumkit Editor</link> or as <link linkend="chpt.pattern_editor.piano_mode">Piano Roll Editor</link>. You can switch between these 
+      two by clicking the 'INPUT' button (TODO: include image) (located on the top-right of the Pattern Editor).
       </para>
       
-      <para>First let's take a look at the (classic) 'Drum' mode.</para>
+      <note>
+        <para>
+          If you are editing a pattern in <emphasis role="bold">Single Pattern Mode</emphasis> you will always hear the pattern you are 
+          editing when you press playback is rolling.
+        </para>
+        <para>
+          If you are working in <emphasis role="bold">Stacked Pattern Mode</emphasis> you will hear the <emphasis>active</emphasis> pattern(s), 
+          not necessarily the pattern you are currently editing.
+          The active patterns have a small triangle next to the pattern name in the Song Editor.  (see <xref linkend="chpt.song_editor.main_controls.single_vs_stacked" /> for details).
+        </para>
+      </note>
       
-      <sect1 id="chpt.pattern_editor.controls"> 
-        <title>Controls</title>
-        
-        <figure id="fig.PatternEditorControls">
-         <title>Pattern Editor Controls</title>
-         <mediaobject>
-           <imageobject>
-             <imagedata fileref="img/PatternEditorControls.png" format="PNG" />
-           </imageobject>
-         </mediaobject>
-        </figure>
+      <sect1 id="chpt.pattern_editor.general"> 
+        <title>General</title>
 
-        <para>The top part of the pattern editor contains a number of controls :</para>
+        <sect2 id="chpt.pattern_editor.controls"> 
+          <title>Controls</title>
+          
+          <figure id="fig.PatternEditorControls">
+            <title>Pattern Editor Controls</title>
+            <mediaobject>
+              <imageobject>
+                <imagedata fileref="img/PatternEditorControls.png" format="PNG" />
+              </imageobject>
+            </mediaobject>
+          </figure>
+
+          <para>
+	        TODO: update image (RES has changed)
+          </para>
+
+          <para>The top part of the Pattern Editor contains a number of controls applying to both the <link linkend="chpt.pattern_editor.drumkit">Drumkit Editor</link> and the <link linkend="chpt.pattern_editor.piano_mode">Piano Roll Editor</link>:</para>
+          
+          <itemizedlist mark="opencircle">
+            <listitem id="chpt.pattern_editor.controls.size">
+              <para><emphasis role="bold">SIZE</emphasis>:
+              lets you choose the length of the pattern (in note values).
+              </para>
+              <para>
+                It will open a dialog to enter the new size as text, in the standard music fractional notation:                  
+              </para>
+              <informalfigure id="fig.PatternSizeDialog">
+                <mediaobject>
+                  <imageobject>
+                    <imagedata fileref="img/PatternSizeDialog.png" format="PNG" />
+                  </imageobject>
+                </mediaobject>
+              </informalfigure>                
+              <para>
+                Type <keycap>/</keycap> to separate numerator and denominator.
+              </para>
+              <para>
+                If you enter just the numerator (e.g. <option>4</option>), the current denominator will be assumed.
+                You can enter a decimal numerator (e.g. <option>4.5/4</option>) but since Hydrogen resolution is limited,
+                some values are not supported and will be approximated.
+              </para>
               
-         <para>From left to right : </para>
-         <itemizedlist mark="opencircle">
-         
-          <!-- TODO DEPRECATED widget. MOVE TO OTHER CHAPTER?? <listitem><para><emphasis role="bold">Note Length / Note off</emphasis> : these are 2 different
-            ways to define the duration of a note. See <xref linkend="chpt.pattern_editor.sequence_area"/> for usage.</para></listitem>  -->
-
-           <listitem>
-                <para><emphasis role="bold">SIZE</emphasis>:
-                    lets you choose the length of the pattern (in note values)
-                </para>
+              <note>
                 <para>
-                   It will open a dialog to enter the new size as text, in the standard music fractional notation:                  
-                </para>
-                <informalfigure id="fig.PatternSizeDialog">
-                     <mediaobject>
-                        <imageobject>
-                          <imagedata fileref="img/PatternSizeDialog.png" format="PNG" />
-                        </imageobject>
-                     </mediaobject>
-                </informalfigure>                
-                <para>
-                   Type '/' to separate numerator and denominator.
-                 </para>
-                 <para>
-                   If you enter just the numerator (e.g. "4"), the current denominator will be assumed.
-                </para>
-                 <para>
-                   You can enter a decimal numerator (e.g. "4.5/4") but since Hydrogen resolution is limited,
-                   some values are not supported and will be approximated.
-                </para>
-                <para>
-                   Hydrogen supports (only) the following denominators: 1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64, 96, 192,
-                     because these are the factors of the maximum resolution (192 ticks per whole note).
-                   You can use unsupported denominators, but the size will be approximated almost all the times,
-                    hence a warning icon will appear:               
+                  Hydrogen supports (only) the following denominators: <option>1</option>, <option>2</option>, <option>3</option>, <option>4</option>, <option>6</option>, <option>8</option>, <option>12</option>, <option>16</option>, <option>24</option>, <option>32</option>, <option>48</option>, <option>64</option>, <option>96</option>, and <option>192</option>
+                  because these are the factors of the maximum resolution (192 ticks per whole note).
+                  You can use unsupported denominators, but the size will be approximated almost all the times,
+                  hence a warning icon will appear:               
                 </para>
                 <informalfigure id="fig.DenominatorWarningIcon">
-                    <mediaobject>
-                        <imageobject>
-                            <imagedata fileref="img/DenominatorWarningIcon.png" format="PNG" />
-                        </imageobject>
-                    </mediaobject>
-                 </informalfigure>
-           </listitem>
+                  <mediaobject>
+                    <imageobject>
+                      <imagedata fileref="img/DenominatorWarningIcon.png" format="PNG" />
+                    </imageobject>
+                  </mediaobject>
+                </informalfigure>
+              </note>
+              
+            </listitem>
 
-           <listitem>
-            <para>
-             <emphasis role="bold">RES</emphasis> : this is the current grid resolution (4 through 64)
-            </para>
-            <para>
+            <listitem id="chpt.pattern_editor.controls.res">
+              <para>
+                <emphasis role="bold">RES</emphasis> : this is the current grid resolution (4 through 64)
+              </para>
+
+              <para>
+	            TODO: update
+              </para>
+              
+              <para>
                 Remember this constraint concerning the grid: if you are working
                 with a resolution of 16 you can't go back to 8 and remove an upbeat 16th note. On
                 the other hand if you are working with a resolution of 8 and you try to
@@ -1744,42 +1756,66 @@
                 notes will be placed in the previous or in the following 8th bar.  This
                 constraint can be removed if you disable the whole grid resolution (choose
                 "off" from the grid resolution LCD control). Now you'll be able to place
-                notes wherever you prefer.</para>
-           </listitem>
+              notes wherever you prefer.</para>
+            </listitem>
+            
+            <listitem><para><emphasis role="bold">HEAR</emphasis> : when enabled Hydrogen 
+            will play back samples as they are being added to the pattern (even if transport is not rolling).
+          </para>
+          <note>
+	        <para>
+	          When disabled you will still hear the preview sound when clicking on the instrument name in the <link linkend="chpt.pattern_editor.sidebar">Sidebar</link>. Be sure to click at the left-most position - where the preview is silent - in case you don't want to get disturbed.
+            </para>
+          </note>
+          
+            </listitem>
+
+            <listitem><para><emphasis role="bold">QUANT</emphasis> : enables/disables quantization.
+            When enabled the beats inserted 
+            will automatically respect the grid resolution currently applied.</para>
+
+            <para>
+	          TODO: this is only relevant for recording, isn't it?
+            </para>
+            
+            </listitem>
+
+            <listitem id="chpt.pattern_editor.controls.input">
+              <para><emphasis role="bold">INPUT</emphasis> : switchs between <link linkend="chpt.pattern_editor.drumkit">Drumkit Editor</link> and <link linkend="chpt.pattern_editor.piano_mode">Piano Roll Editor</link>.</para>
+            </listitem>
+
+          </itemizedlist>
+
+          <para>
+	        TODO: add button images to list.
+          </para>
+
+        </sect2>
         
-           <listitem><para><emphasis role="bold">HEAR</emphasis> : when enabled Hydrogen 
-           will play the sample as it's being added to the pattern.</para></listitem>
+        <sect2 id="chpt.pattern_editor.sidebar">
+	      <title>Sidebar</title>
 
-           <listitem><para><emphasis role="bold">QUANT</emphasis> : enables/disables quantization.  
-           When enabled the beats inserted 
-            will automatically respect the grid resolution currently applied.</para></listitem>
+          <para>
+            <inlinemediaobject id="ifig.pattern_editor_instrument">
+              <imageobject>
+                <imagedata fileref="img/PatternEditorInstr_V2.png" format="PNG" />
+              </imageobject>
+            </inlinemediaobject>
+          </para>
 
-           <listitem><para><emphasis role="bold">INPUT</emphasis> : switch Pattern Editor 
-           between Drum and Piano mode. (see below)</para></listitem>
+          <para>
+	        TODO: include pattern and drumkit name above the instrument list and mention them in the paragraph below. + update image
+          </para>
 
-         </itemizedlist>
-
-      </sect1>
-      
-      <sect1 id="chpt.pattern_editor.drumkit">
-        <title>Drumkit Editor</title>
-        
-        <para>
-          <inlinemediaobject id="ifig.pattern_editor_instrument">
-            <imageobject>
-              <imagedata fileref="img/PatternEditorInstr_V2.png" format="PNG" />
-            </imageobject>
-          </inlinemediaobject>
-        </para>
-     
-        <para>The section on the left shows you what drumkit is currently selected (GMkit by default) and below that you can see
+        <para>The section on the left shows you what drumkit is currently selected (GMRockKit by default) and below that you can see
         the instruments that are part of this kit.</para>
      
         <para>Each instrument has its own set of features that are accessible by 
-        right-clicking the instrument.  From the context menu that pops up you can select </para>
+        <keycap>right-clicking</keycap> the instrument.  From the context menu that pops up you can select </para>
         <itemizedlist mark="opencircle"> 
           <listitem><para><emphasis role="bold">Clear notes</emphasis> : to remove all notes for this instrument in this pattern.  </para></listitem>
-          <listitem><para><emphasis role="bold">Fill notes</emphasis> : this allows you to fill
+          <listitem id="chpt.pattern_editor.sidebar.fill_notes">
+            <para><emphasis role="bold">Fill notes</emphasis> : this allows you to fill
           up the pattern with notes for the selected instrument.  Depending on the choice you make (fill all, fill 1/2, fill 1/4 ...)
           notes will be placed at all, 1/2, 1/4, etc of the note positions <emphasis role="bold">that are allowed by 
           the grid setting</emphasis>.  So be careful not to mix up the 'musical' 1/2-note and the 'fill 1/2' note.</para></listitem>
@@ -1791,32 +1827,49 @@
           </para></listitem>
           <listitem><para><emphasis role="bold">Delete Instrument</emphasis> : well, deletes the instrument ;-)</para></listitem>
         </itemizedlist>
+
+        <para>
+	      TODO: update list
+        </para>
         
         <para>The small red and green buttons right of the instrument names are the
         <quote><emphasis role="bold">mute</emphasis></quote> (red) and <quote><emphasis
         role="bold">solo</emphasis></quote> (green) buttons.</para>
 
+        <para>
+	      TODO: update mute and solo + use button images in description
+        </para>
+        
         <para>The order of the instruments can be rearranged by simply dragging an instrument 
         up/down in the list and dropping it on a new position within the drumkit.  Doing so 
         will not change anything to the sequence you have created for that instrument, nor will
         it change anything to the song or pattern you are working on.  It <emphasis role="bold">
-        will</emphasis> however, have an impact on the <emphasis role="bold"><abbrev>MIDI</abbrev> note 
+        will</emphasis> however, have an <emphasis role="bold">impact</emphasis> on the <emphasis role="bold"><abbrev>MIDI</abbrev> note 
         mapping</emphasis> : in the table below you can find the link between the instrument
-        position, the <abbrev>MIDI</abbrev> note and the qwerty keyboard keys.</para>
+        position, the <abbrev>MIDI</abbrev> note and the <abbrev>qwerty</abbrev> keyboard keys.</para>
 
-      <para><emphasis role="bold">Important Notes</emphasis> :</para>
-      <para>The name of the instrument depends on the
-      drumkit that is loaded. This list below refers to the GMkit that is loaded by default.
-      </para>
-      <para>Try to follow the GM midi standard as accurately as possible.  This will ensure that switching between 
+        <note>
+	      <para>
+	        The name of the instrument depends on the
+            drumkit that is loaded. This list below refers to the GMkit that is loaded by default.
+          </para>
+        </note>
+
+        <para>
+	      TODO: since the GMKit is not offered anymore, we should update this to match the GMRockKit
+        </para>
+
+        <para>
+	      TODO: this might be better placed in the MIDI chapter.
+        </para>
+        
+        <para>Try to follow the <emphasis role="bold">General <abbrev>MIDI</abbrev> (GM)</emphasis> standard as accurately as possible.  This will ensure that switching between 
       drumkits goes smoothly.  You are of course free to place your instruments anywhere in your drumkit, and
       sometimes it isn't even possible to follow the GM standard, but it makes life a lot easier if you do.</para>
       <para>
       Keep in mind that it is the <emphasis>position</emphasis> of the instrument (within the loaded drumkit) that 
       is linked to a <abbrev>MIDI</abbrev>-note/keyboard-key and <emphasis>not the name</emphasis> of the instrument.
       </para>
-
-
 
       <informalfigure id="fig.InstrumentMapping">
         <mediaobject>
@@ -1836,15 +1889,25 @@
           </imageobject>
         </mediaobject>
       </informalfigure>
-      </sect1>
+    </sect2>
+  </sect1>
 
-      <sect1 id="chpt.pattern_editor.sequence_area">
-      <title>Sequence Area</title>
-        <para>This is where it all happens, this is where you can make music :-)</para>
-        <para>In this area you can see your selected pattern and add notes for any instrument. 
-        The simplest way to create a pattern is by adding notes using your mouse 
-        (and the 'Fill/Clear notes' function described above). Where you can add notes
-        depends on the used pattern size and resolution.</para>
+      <sect1 id="chpt.pattern_editor.drumkit">
+        <title>Drumkit Editor</title>
+
+        <figure id="fig.PatternEditor_drumkit">
+         <title>Pattern Editor in Drum Mode</title>
+         <mediaobject>
+           <imageobject>
+             <imagedata fileref="img/PatternEditor_DrumMode.png" format="PNG" />
+           </imageobject>
+         </mediaobject>
+        </figure>
+
+
+        <para>Right of the <link linkend="chpt.pattern_editor.sidebar">Sidebar</link> area you can see your selected pattern and add notes for any instrument. 
+        The simplest way to create a pattern is by adding notes using <link linkend="chpt.pattern_editor.sidebar.fill_notes">Fill notes</link>. Where you can add notes
+        depends on the used pattern <link linkend="chpt.pattern_editor.controls.size">size</link> and <link linkend="chpt.pattern_editor.controls.res">resolution</link>.</para>
         <para>If you are using Hydrogen as a pure 'drum' you just want Hydrogen to 'hit' 
         the instrument wherever there's a 'dot' in the pattern. If you are using Hydrogen as an 'instrument', the 
         length of the note becomes very important. There are 2 ways to define the length of
@@ -1853,7 +1916,7 @@
         <itemizedlist>
           <listitem>
             <para>
-              you can add a note by left-clicking, and then can 'stretch' that note by right-click-dragging it.
+              you can add a note by <keycap>left-clicking</keycap>, and then can 'stretch' that note by <keycap>right-click-dragging</keycap> it.
               This will change the dot into a rectangle that represents the
               duration of that note.
             </para>
@@ -1861,7 +1924,7 @@
           <listitem>
             <para>
               Alternatively, you can add a stop-note by
-              Shift+left-clicking. This adds a blue dot which
+              <keycap>Shift</keycap> + <keycap>left-clicking</keycap>. This adds a blue dot which
               represents the end of the note.
             </para>
           </listitem>
@@ -1880,28 +1943,24 @@
         <para>
           As in the Song Editor, the arrow keys can also be used to
           move around the pattern, and notes can be placed or removed
-          with Return.
+          with <keycap>Return</keycap> (see <xref linkend="chpt.keyboard_and_mouse" />.
         </para>
 
         <para>
-          Notes can be selected by dragging over them with the mouse (or <emphasis
-          role="bold">Shift+arrow keys</emphasis>), and can be deleted with 'Delete', or moved by
-          dragging (or Return followed by arrow key movements) the notes to a new location. This
+          Notes can be selected by dragging over them with the mouse (or <keycap>Shift</keycap> + <keycap>↑</keycap>|<keycap>↓</keycap>|<keycap>←</keycap>|<keycap>→</keycap>), and can be deleted with <keycap>Delete</keycap>, or moved by
+          <keycap>dragging</keycap> (or <keycap>Return</keycap> followed by <keycap>↑</keycap>|<keycap>↓</keycap>|<keycap>←</keycap>|<keycap>→</keycap> movements) the notes to a new location. This
           allows notes to be moved between different instruments, or to adjust their
           timing. Movement in the horizontal direction is constrained by the currently selected grid
-          resolution, however this can be overridden by holding down <emphasis
-          role="bold">Alt</emphasis> while moving notes.
+          <link linkend="chpt.pattern_editor.controls.res">resolution</link>, however this can be overridden by holding down <keycap>Alt</keycap> while moving notes.
         </para>
 
         <para>
-          Moving a selection of notes with <emphasis role="bold">Ctrl</emphasis> held down will copy
+          Moving a selection of notes with <keycap>Ctrl</keycap> held down will copy
           them to the new location rather than moving, as in the Song Editor.
         </para>
 
         <para>
-          Selected notes can also be copied to the clipboard with <emphasis
-          role="bold">Ctrl+C</emphasis>, and pasted with <emphasis
-          role="bold">Ctrl+V</emphasis>. When pasting, the relative positions of the input cursor at
+          Selected notes can also be copied to the clipboard with <keycap>Ctrl</keycap> + <keycap>C</keycap>, and pasted with <keycap>Ctrl</keycap> + <keycap>V</keycap>. When pasting, the relative positions of the input cursor at
           the time of the Copy and Paste operation will set the new position of pasted notes.
         </para>
 
@@ -1911,12 +1970,15 @@
            <imagedata fileref="img/Rec_button.png" format="PNG"/>
           </imageobject>
          </inlinemediaobject>
-        (see <xref linkend="chpt.main_menu"/>) and simply playing your pattern on your 
-        <abbrev>MIDI</abbrev> drum or your pc keyboard (see instrument mapping above).  This is probably 
+        (see <xref linkend="sect.main_toolbar.transport_control"/>) and simply playing your pattern on your 
+        <abbrev>MIDI</abbrev> drum or your pc keyboard (see <link linkend="chpt.pattern_editor.sidebar">instrument mapping</link>). (TODO: there is no dedicated section/chapter on recording. But there should be one which is easily discoverable in the table of content)  This is probably 
         a more musical way of creating a pattern, but it's up to you to decide what works best for you.
         (Also see <xref linkend="chpt.create_song"/> for a basic
-        walk-through of how the pattern editor works) </para>
- 
+        walk-through of how the Pattern Editor works) </para>
+
+        <para>
+	      TODO: verify if up-to-date
+        </para>
       </sect1>
       
       <sect1 id="chpt.pattern_editor.note_properties">
@@ -1927,9 +1989,12 @@
       <para>Clicking on an instrument or adding/removing a note next to it 
       will select this instrument.  Once an instrument is selected the note properties 
       for this instrument will be shown in the form of vertical lines in the bottom window.  
-      The lines represent the value for the selected property of each note of the selected instrument.
+      The lines represent the values for the selected property of each note of the selected instrument.
       You can select a different note-property from the note property drop-down list (located bottom-left).
-      There are 4 note properties available : 
+      </para>
+
+      <para>
+      The following note properties are available: 
       
       <itemizedlist mark="opencircle">
         <listitem>
@@ -1937,11 +2002,14 @@
           played (the volume of the note)</para>
           <note>
             <para>
-          Note that the color of the note-dot and the vertical bar will change according to the velocity value you have defined. 
+          The color of the vertical bar will change according to the velocity value you have defined. 
           A light shade of gray means a low velocity (low volume) and the higher you set the velocity the darker the color will be,
           turning red when you reach the point of clipping.
             </para>
           </note>
+          <para>
+	        TODO: link to Instrument Editor -> Layers which describes how velocity maps to different samples.
+          </para>
         </listitem>
         
         <listitem>
@@ -1949,10 +2017,13 @@
            the stereo image position of the note (how loud it will be in the
           left/right output).</para>
           <note>
-           <para>Note that the effect of <emphasis>note Pan</emphasis> depends on the <emphasis>instrument Pan</emphasis>
-            knob, which is set in the mixer.
+           <para>The effect of <emphasis>note Pan</emphasis> depends on the <emphasis>instrument Pan</emphasis>
+            knob, which is set in the <link linkend="chpt.mixer">Mixer</link>.
            Look to next figure to see how the <emphasis role="bold"><emphasis>Resultant Pan</emphasis></emphasis>
            is determined (from version 1.1):
+
+	         TODO: replace "note Pan" and "instrument Pan" with links pointing to the particular sections
+           
            <informalfigure id="matryoshkaPanning">
             <mediaobject>
               <imageobject>
@@ -1984,9 +2055,9 @@
           </para>
         </listitem>
         
-        <listitem>
+        <listitem id="chpt.pattern_editor.note_properties.notekey">
           <para>
-          <emphasis role="bold">Notekey</emphasis> : if you select this note parameter the 
+          <emphasis role="bold">NoteKey</emphasis> : if you select this note parameter the 
           area where you can modify the parameter will change into a 'piano keyboard'
           </para>
           <informalfigure id="fig.NoteKey">
@@ -2003,11 +2074,10 @@
             value.
           </para>
           <note>
-          <para>
-            Note that the pattern editor in piano roll mode (see <xref
-            linkend="chpt.pattern_editor.piano_mode" />) can also be used to
-            change the note value of existing notes
-          </para>
+            <para>
+            Note that the <link linkend="chpt.pattern_editor.piano_mode">Piano Roll Editor</link> can also be used to
+            change the note value of existing notes.
+            </para>
           </note>
         </listitem>
         <listitem>
@@ -2026,7 +2096,7 @@
       </para>
 
       <para>
-        Clicking or dragging the value lines in the note properties editor will
+        <keycap>Clicking</keycap> or <keycap>dragging</keycap> the value lines in the Note Properties Editor will
         set the property value. But often you'll want to set the properties of
         several notes at once, so there are a few ways to do this.
 
@@ -2056,7 +2126,7 @@
       </sect1>
 
       <sect1 id="chpt.pattern_editor.piano_mode">
-        <title>Piano Mode Editor</title>
+        <title>Piano Roll Editor</title>
         
        <figure id="fig.PatternEditor_PianoMode">
          <title>Pattern Editor in Piano Mode</title>
@@ -2066,13 +2136,19 @@
            </imageobject>
          </mediaobject>
        </figure>
-       
-       <para>Drum mode (see <xref linkend="fig.PatternEditor_DrumMode"/>) focuses on using Hydrogen as a drum machine.
-       If you are using Hydrogen as an instrument there is a big chance that the Piano mode is for you.
+
+       <para>
+	     The Pattern Editor can be used as Piano Roll Editor pressing the <link linkend="chpt.pattern_editor.controls.input">Input</link> button.
+       </para>
+       <para>While the <link linkend="chpt.pattern_editor.drumkit">Drumkit Editor</link> focuses on using Hydrogen as a drum machine, you can also use it an instrument via the Piano Roll Editor.
        It gives you a complete 'piano keyboard' so you can easily put down your tunes.</para>
-       <para>You can compare the Piano mode to the Note properties Notekey (described above), only here you have a 
+       <para>You can compare the Piano mode to the <link linkend="chpt.pattern_editor.note_properties.notekey">NoteKey</link> property in the Note Properties Editor. Only here you have a 
        complete piano keyboard, so you don't have to select the octave
        first.</para>
+
+       <para>
+	     TODO: add additional information about change properties of multiple notes at a single position, what happens in the Drumkit Editor when there are multiple notes in a single position, that most (all?) of the controls - like note lengths - available in the Drumkit Editor can also be applied here.
+       </para>
       
       </sect1>
      

--- a/manual.docbook
+++ b/manual.docbook
@@ -166,6 +166,118 @@
       
     </chapter>
 
+<!--   KEYBOARD AND MOUSE -->
+    <chapter id="chpt.keyboard_and_mouse">
+      <title>Keyboard and Mouse</title>
+      <para>
+        The Hydrogen user interface is designed so that it can be
+        used entirely with the mouse, with the exception of text entry.
+      </para>
+      <para>
+        The keyboard can also be used for navigating and editing in
+        the pattern and song editors, using a combination of 
+        <itemizedlist>
+          <listitem>
+            <para>
+              <emphasis role="bold"><keycap>↑</keycap>|<keycap>↓</keycap>|<keycap>←</keycap>|<keycap>→</keycap></emphasis> : move the
+              keyboard input cursor's position, or adjust values under
+              the cursor.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <emphasis role="bold"><keycap>Shift</keycap> + <keycap>↑</keycap>|<keycap>↓</keycap>|<keycap>←</keycap>|<keycap>→</keycap></emphasis> :
+              can be used to make selections of notes or pattern
+              groups as if the mouse had been dragged over them.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <emphasis role="bold"><keycap>Enter</keycap> and <keycap>Return</keycap></emphasis> : generally
+              performs the same action as a mouse click, but can also
+              start or end a move (or copy) of items in the same way
+              a mouse drag would.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <emphasis role="bold"><keycap>Tab</keycap> and <keycap>Shift</keycap> + <keycap>Tab</keycap></emphasis> : move
+              between different areas of the main interface.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <emphasis role="bold"><keycap>Delete</keycap></emphasis> :
+              delete notes or patterns.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <emphasis role="bold"><keycap>Esc</keycap></emphasis> :
+              cancels an ongoing selection, move or copy.
+            </para>
+          </listitem>
+        </itemizedlist>
+      </para>
+      <note>
+        <para>
+        Note that the keyboard input cursor is hidden
+        from view until one of the above keys is pressed. This keeps
+        the display clear and uncluttered when using the mouse.
+        </para>
+      </note>
+      <para>
+        Most other keys on the keyboard can be used to play
+        samples and enter notes in the same way a <abbrev>MIDI</abbrev> keyboard can be.
+      </para>
+    </chapter>
+
+</part>
+
+  <!--
+      ####################
+      # SECOND CHAPTER   #
+      ####################
+  -->
+
+  <part id="part.using_hydrogen">
+    <title>Using Hydrogen</title>
+
+<!--   UI OVERVIEW  -->
+    <chapter id="chpt.UIoverview">
+      <title>Overview</title>
+
+      <para>The Main UI comes in 2 flavors : the (classic) Single Pane mode (ideal for
+      large- and medium size screens), and the Tabbed mode (optimized for netbook screen 
+      sizes).
+      </para>
+      <para>
+      Below you can see the main UI split up in 5 parts : the Main Menu, Main 
+      Toolbar, Song Editor, Pattern Editor and the Instrument and Sound Library Editor.
+        These sections will be explained in detail further down in this manual.</para>
+      
+      <figure id="fig.UI_overview">
+        <title>The Main UI in Single Pane mode</title>
+
+        <mediaobject>
+          <imageobject>
+            <imagedata fileref="img/GUI_Sections_0.9.5_v2.png" format="PNG"/>
+          </imageobject>
+        </mediaobject>
+      </figure>
+
+      <figure id="fig.tabbed_UI_overview">
+        <title>The Main UI in Tabbed mode</title>
+
+        <mediaobject>
+          <imageobject>
+            <imagedata fileref="img/MainUI_tabbed.png" format="PNG"/>
+          </imageobject>
+        </mediaobject>
+      </figure>
+      
+    </chapter>
+
     <chapter id="chpt.preferences" xreflabel="Preferences">
       <title>Preferences</title>
 
@@ -174,7 +286,7 @@
       menu (tools -&gt; preferences).</para>
 
       <sect1 id="chpt.preferences.general_tab">
-        <title>The General tab</title>
+        <title>General</title>
         
         <para>On the "General" tab (<xref linkend="fig.preferences.general_tab"/>) you can 
         choose to automatically reopen the last used song and/or playlist.  This can save you 
@@ -183,9 +295,9 @@
         <para>If you want to use <abbrev>LASH</abbrev> for session management you should enable 
         it here so Hydrogen allows interaction with <abbrev>LASH</abbrev>.</para>
         <para>The Beat Counter drift compensation and start offset allow you to compensate
-         for system latency when you are using the Beat Counter function (see <xref linkend="sect.tap_tempo"/>)</para>
+         for system latency when you are using the Beat Counter function (see <xref linkend="sect.main_toolbar.tap_tempo_beat_counter"/>)</para>
         <para>The Max number of bars in a song can be set here (currently limited to 800) 
-        and if you want to use rubberband for sample time-stretching (see <xref linkend="sect.layer_editing.section2"/>)
+        and if you want to use rubberband for sample time-stretching (see <xref linkend="chpt.sample_editor.section2"/>)
         you need to enter the path where rubberband is installed on you system here.</para>
         <!-- THIJS : NEED TO AD LINK TO SAMPLE EDITOR -->
         
@@ -202,7 +314,7 @@
       </sect1>
 
       <sect1 id="chpt.preferences.audio_tab">
-        <title>The Audio System tab</title>
+        <title>Audio System</title>
 
         <para>From the "Audio System" tab (<xref
         linkend="fig.preferences.audio_tab"/>) it is possible to modify the
@@ -271,7 +383,7 @@
                 tempo information instead of the local one of either the Song's
                 tempo (see <xref linkend="chpt.main_toolbar"/>) or the markers
                 added to the Timeline (see <xref
-                linkend="chpt.song_editor.tempo_and_markers"/>).  But due to
+                linkend="chpt.song_editor.timeline"/>).  But due to
                 limitations in the current implementation, Hydrogen can not set
                 both measure and speed provided by <abbrev>JACK</abbrev> for arbitrary pattern
                 combinations. The user has two options. Either drop all measure
@@ -338,9 +450,9 @@
       </sect1>
 
       <sect1 id="chpt.preferences.midi_tab">
-        <title>The Midi System tab</title>
+        <title>MIDI System</title>
 
-        <para>The "Midi System" tab (<xref linkend="fig.preferences.midi_tab"/>)
+        <para>The "MIDI System" tab (<xref linkend="fig.preferences.midi_tab"/>)
         contains all <abbrev>MIDI</abbrev> settings. Here you can choose the <abbrev>MIDI</abbrev> driver (<abbrev>ALSA</abbrev>, PortMidi, 
         CoreMidi or JackMidi) input, and channel(s) that Hydrogen should respond to.  
         You can also define midi bindings: link a midi note/message to an action. 
@@ -370,7 +482,7 @@
       </sect1>
 
       <sect1 id="chpt.preferences.osc_tab">
-        <title>The OSC tab</title>
+        <title>OSC</title>
 
         <para>The <abbrev>OSC</abbrev> tab (<xref linkend="fig.preferences.osc_tab"/>) let's
         you modify all options associated with <abbrev>OSC</abbrev> (Open Sound Control) (see
@@ -441,7 +553,7 @@
 
 
       <sect1 id="chpt.preferences.appearance_tab">
-        <title>The Appearance tab</title>
+        <title>Appearance</title>
 
         <para>The "Appearance" tab (<xref
         linkend="fig.preferences.appearance_tab"/>) let's you modify Hydrogen look 
@@ -460,181 +572,14 @@
         </figure>
       </sect1>
 
-
-      <sect1 id="chpt.preferences.audio_engine_tab">
-        <title>The Audio Engine tab (debug only)</title>
-
-        <para>The "Audio Engine" tab (<xref linkend="fig.preferences.audio_engine_tab"/>) is a window that shows
-        various stats about Hydrogen and the audio driver. In case <abbrev>JACK</abbrev> is used,
-        buffer and sampling rate should be set in the configuration of the <abbrev>JACK</abbrev>
-        server before starting Hydrogen (<abbrev>JACK</abbrev> automatically starts when an
-        application tries to connect).</para>
-        <note>
-          <para>
-            Note that the Audio Engine tab is only available if Hydrogen was compiled with 
-            debug support.
-          </para>
-        </note>
-
-        <figure id="fig.preferences.audio_engine_tab">
-          <title>The Audio Engine tab</title>
-          <mediaobject>
-            <imageobject>
-              <imagedata fileref="img/AudioEngineInfoDialog.png" format="PNG"/>
-            </imageobject>
-          </mediaobject>
-        </figure>
-      </sect1>
-  </chapter>
-</part>
-
-  <!--
-      ####################
-      # SECOND CHAPTER   #
-      ####################
-  -->
-
-  <part id="part.using_hydrogen">
-    <title>Using Hydrogen</title>
-
-<!-- FILETYPES -->
-    <chapter id="chpt.file_types">
-      <title>Used Filetypes</title>
-
-      <para>Before working with Hydrogen, please familiarize with these
-      filetypes:</para>
-
-      <itemizedlist>
-        <listitem>
-          <para><emphasis role="bold">*.h2pattern</emphasis>: <abbrev>XML</abbrev> file
-          describing a single pattern. Patterns are group of beats and are
-          managed in the pattern editor.</para>
-        </listitem>
-        <listitem>
-          <para><emphasis role="bold">*.h2song</emphasis>: <abbrev>XML</abbrev> file describing
-          the whole song (or sequence). Songs are group of patterns with their
-          properties and are manager using the song editor</para>
-        </listitem>
-        <listitem>
-          <para><emphasis role="bold">*.h2playlist</emphasis>: <abbrev>XML</abbrev> file
-          describing a playlist. A Playlist is a (ordered) group of songs.</para>
-        </listitem>
-        <listitem>
-          <para><emphasis role="bold">*.h2drumkit</emphasis>: a compressed and
-          archived folder containing all sound samples composing a drumkit and a
-          description <abbrev>XML</abbrev> file. Drumkits are basically group of sound
-          samples.</para>
-        </listitem>
-      </itemizedlist>
     </chapter>
-
-<!--   KEYBOARD AND MOUSE -->
-    <chapter id="chpt.keyboard_and_mouse">
-      <title>Keyboard and Mouse</title>
-      <para>
-        The Hydrogen user interface is designed so that it can be
-        used entirely with the mouse, with the exception of text entry.
-      </para>
-      <para>
-        The keyboard can also be used for navigating and editing in
-        the pattern and song editors, using a combination of 
-        <itemizedlist>
-          <listitem>
-            <para>
-              <emphasis role="bold"><keycap>↑</keycap>|<keycap>↓</keycap>|<keycap>←</keycap>|<keycap>→</keycap></emphasis> : move the
-              keyboard input cursor's position, or adjust values under
-              the cursor.
-            </para>
-          </listitem>
-          <listitem>
-            <para>
-              <emphasis role="bold"><keycap>Shift</keycap> + <keycap>↑</keycap>|<keycap>↓</keycap>|<keycap>←</keycap>|<keycap>→</keycap></emphasis> :
-              can be used to make selections of notes or pattern
-              groups as if the mouse had been dragged over them.
-            </para>
-          </listitem>
-          <listitem>
-            <para>
-              <emphasis role="bold"><keycap>Enter</keycap> and <keycap>Return</keycap></emphasis> : generally
-              performs the same action as a mouse click, but can also
-              start or end a move (or copy) of items in the same way
-              a mouse drag would.
-            </para>
-          </listitem>
-          <listitem>
-            <para>
-              <emphasis role="bold"><keycap>Tab</keycap> and <keycap>Shift</keycap> + <keycap>Tab</keycap></emphasis> : move
-              between different areas of the main interface.
-            </para>
-          </listitem>
-          <listitem>
-            <para>
-              <emphasis role="bold"><keycap>Delete</keycap></emphasis> :
-              delete notes or patterns.
-            </para>
-          </listitem>
-          <listitem>
-            <para>
-              <emphasis role="bold"><keycap>Esc</keycap></emphasis> :
-              cancels an ongoing selection, move or copy.
-            </para>
-          </listitem>
-        </itemizedlist>
-      </para>
-      <note>
-        <para>
-        Note that the keyboard input cursor is hidden
-        from view until one of the above keys is pressed. This keeps
-        the display clear and uncluttered when using the mouse.
-        </para>
-      </note>
-      <para>
-        Most other keys on the keyboard can be used to play
-        samples and enter notes in the same way a <abbrev>MIDI</abbrev> keyboard can be.
-      </para>
-    </chapter>
-
-<!--   UI OVERVIEW  -->
-    <chapter id="chpt.UIoverview">
-      <title>The main User Interface : an overview</title>
-
-      <para>The Main UI comes in 2 flavors : the (classic) Single Pane mode (ideal for
-      large- and medium size screens), and the Tabbed mode (optimized for netbook screen 
-      sizes).
-      </para>
-      <para>
-      Below you can see the main UI split up in 5 parts : the Main Menu, Main 
-      Toolbar, Song Editor, Pattern Editor and the Instrument and Sound Library Editor.
-        These sections will be explained in detail further down in this manual.</para>
-      
-      <figure id="fig.UI_overview">
-        <title>The Main UI in Single Pane mode</title>
-
-        <mediaobject>
-          <imageobject>
-            <imagedata fileref="img/GUI_Sections_0.9.5_v2.png" format="PNG"/>
-          </imageobject>
-        </mediaobject>
-      </figure>
-
-      <figure id="fig.tabbed_UI_overview">
-        <title>The Main UI in Tabbed mode</title>
-
-        <mediaobject>
-          <imageobject>
-            <imagedata fileref="img/MainUI_tabbed.png" format="PNG"/>
-          </imageobject>
-        </mediaobject>
-      </figure>
-      
-    </chapter>
-
+    
 <!--  MAIN MENU -->
     <chapter id="chpt.main_menu">
-      <title>Main menu</title>
+      <title>Main Menu</title>
 
       <sect1 id="sect.main_menu.projects">
-        <title>Main menu > Projects</title>
+        <title>Projects</title>
         <para>This menu offers file
         related functions.</para>
 
@@ -679,9 +624,73 @@
             <para><emphasis role="bold">Export MIDI file</emphasis>: export current song in
             <abbrev>MIDI</abbrev> format</para>
           </listitem>
-          <listitem>
+          <listitem id="sect.main_form.export_song" xreflabel="Export Song">
             <para><emphasis role="bold">Export song</emphasis>: export current song in WAV
-            format (see <xref linkend="chpt.song_editor.export_song"/>)</para>
+            format.</para>
+            
+            <para>Once your song is finished you can export it to an audio file.
+            This audio file can then be played on your favorite media player or imported
+            in an other audio application.</para>
+            <para>
+              To do this, go to Project - "Export song" and the following window will pop up:
+              <figure id="fig.Export_song">
+                <title>Export a Song</title>
+                <mediaobject>
+                  <imageobject>
+                    <imagedata fileref="img/Export_song.png" format="PNG" />
+                  </imageobject>
+                </mediaobject>
+              </figure>
+              To export a song you need to do 3 things:
+              
+            </para>
+            
+            <procedure>
+
+              <step>
+                <para>Enter a name and location for the export file in the 'Export filename' field
+                </para>
+              </step>
+              
+              <step>
+                <para>Select one of the available templates (e.g. CD, DAT ...) according to your needs:  
+                each template has a specific bitrate, resolution, and audio format (WAV, AIFF, FLAC or OGG).
+                You can tweak the selected template using the samplerate/sampledepth dropdown boxes
+                underneath the template field.
+                
+                </para>
+              </step>
+              
+              <step>
+                <para>Export mode: 'Export to a single track' will export 1 stereo downmix of your 
+                song (= the master output).  'Export to separate tracks' will create files for each 
+                instrument/track.  'Both' will create a stereo downmix + audio files for all individual
+                instruments.
+                </para>
+              </step>
+              
+            </procedure>
+            
+            <para>
+              Once all these settings have been configured all you need to do is click the 'Export'
+              button and Hydrogen will generate the requested files.
+            </para>
+
+            <note>
+              <para>
+                If you have tempo changes in your song (see <xref linkend="chpt.song_editor.timeline"/>) 
+                these tempo changes will not be exported.  This is a know limitation of the current versions 
+                (including 0.9.6)
+              </para>
+              <para>
+                As a workaround you can record the output of Hydrogen with an audio recording
+                application (like Ardour, Qtractor ...)
+              </para>
+            </note>
+
+            <para>
+	          TODO: fuse
+            </para>
           </listitem>
           <listitem>
             <para><emphasis role="bold">Export Lilypond file</emphasis>: this is a first version of the LilyPond export.
@@ -694,7 +703,7 @@
       </sect1>
 
       <sect1 id="sect.main_menu.undo">
-        <title>Main menu > Undo</title>
+        <title>Undo</title>
         <para>Undo/Redo functions.</para>
         
         <itemizedlist>
@@ -712,7 +721,7 @@
       </sect1>
 
       <sect1 id="sect.main_menu.instruments">
-        <title>Main menu > Instruments</title>
+        <title>Instruments</title>
         <para>This menu offers
         instruments functions.</para>
 
@@ -741,7 +750,7 @@
       </sect1>
 
       <sect1 id="sect.main_menu.drumkits">
-        <title>Main menu > Drumkits</title>
+        <title>Drumkits</title>
         <para>This menu offers drumkit (sound libraries) functions.</para>
         <itemizedlist>
           <listitem>
@@ -754,11 +763,26 @@
             <emphasis>$HOME/.hydrogen/data/library_name</emphasis>
             </para>
           </listitem>
-          <listitem>
+          <listitem id="sect.main_form.import_drumkit">
             <para><emphasis role="bold">Import</emphasis>: imports another drumkit from the local filesystem.
-            To load another drumkit in your
-            current working session of Hydrogen, read <xref
-            linkend="chpt.sound_library"/>.
+            </para>
+            <para>
+              You can import existing drumkits from other users via <menuchoice>
+              <guimenu>Instruments</guimenu><guimenuitem>Import library</guimenuitem>
+              </menuchoice>.  The Import window will pop up with the Internet tab selected.
+              By default the link to the drumkit list (on hydrogen-music.org) will be filled in, 
+              and after pressing the 'Update list' button you will get a complete list of all
+              drumkits that are available for download.  In the status column you can see
+              if a kit is installed or not.
+
+              <figure id="fig.import_drumkit">
+                <title>Import Drumkit</title>
+                <mediaobject>
+                  <imageobject>
+                    <imagedata fileref="img/Sound_Library_import.png" format="PNG" />
+                  </imageobject>
+                </mediaobject>
+              </figure>
             </para>
           </listitem>
           <listitem>
@@ -774,7 +798,7 @@
       </sect1>
 
       <sect1 id="sect.main_menu.view">
-        <title>Main menu > View</title>
+        <title>View</title>
         <para>Opens the director, the playlist editor, the instrument rack
         and the general preferences window.
         </para>
@@ -813,7 +837,7 @@
       </sect1>
 
       <sect1 id="sect.main_menu.options">
-        <title>Main menu > Options</title>
+        <title>Options</title>
         <para>Selects the input mode and opens the general preferences
         window.</para>
 
@@ -837,16 +861,34 @@
       </sect1>
 
       <sect1 id="sect.main_menu.debug">
-        <title>Main menu > Debug</title>
+        <title>Debug</title>
         <para>Tools mainly for debugging
         and monitoring Hydrogen (only available when compiled with debug
         support !).</para>
 
         <itemizedlist>
-          <listitem>
-            <para><emphasis role="bold">Show audio engine info</emphasis>: open a monitor
-            with various <link
-            linkend="chpt.preferences.audio_engine_tab">stats</link></para>
+          <listitem id="chpt.preferences.audio_engine_tab">
+            <para><emphasis role="bold">Show audio engine info</emphasis>: opens a window that shows
+            various stats about Hydrogen and the audio driver. In case <abbrev>JACK</abbrev> is used,
+            buffer and sampling rate should be set in the configuration of the <abbrev>JACK</abbrev>
+            server before starting Hydrogen (<abbrev>JACK</abbrev> automatically starts when an
+            application tries to connect).</para>
+            <note>
+              <para>
+                Note that the Audio Engine tab is only available if Hydrogen was compiled with 
+                debug support.
+              </para>
+            </note>
+
+            <figure id="fig.preferences.audio_engine_tab">
+              <title>The Audio Engine View</title>
+              <mediaobject>
+                <imageobject>
+                  <imagedata fileref="img/AudioEngineInfoDialog.png" format="PNG"/>
+                </imageobject>
+              </mediaobject>
+            </figure>
+
           </listitem>
           <listitem>
             <para><emphasis role="bold">debug action</emphasis>: insert debug
@@ -860,7 +902,7 @@
       </sect1>
 
       <sect1 id="sect.main_menu.info">
-        <title>Main menu > Info</title>
+        <title>Info</title>
 
         <itemizedlist>
           <listitem>
@@ -885,7 +927,7 @@
 
 <!--   MAIN TOOLBAR  -->
     <chapter id="chpt.main_toolbar">
-      <title>The main toolbar</title>
+      <title>Main Toolbar</title>
 
       <para>Before analyzing the two main frames of Hydrogen, let's take a quick
       look at the main toolbar and its components:</para>
@@ -903,7 +945,7 @@
           <para>An advanced tap tempo function: choose note length and how many
           notes to wait before recalculating BPM, then hit the comma key
           repeatedly until the 'R' letter appears and then the BPM will be
-          updated.  (see <xref linkend="sect.tap_tempo"/>)</para>
+          updated.  (see <xref linkend="sect.main_toolbar.tap_tempo_beat_counter"/>)</para>
         </listitem>
         <listitem>
           <para>Manually set BPM</para>
@@ -916,9 +958,13 @@
         </listitem>
       </itemizedlist>
 
+      <para>
+	    TODO: drop this apart from the image
+      </para>
+
       <figure id="fig.main_toolbar">
         <title>The Main Toolbar</title>
-
+        
         <mediaobject>
           <imageobject>
             <imagedata fileref="img/MainToolbar_V2.png" format="PNG"/>
@@ -926,105 +972,35 @@
         </mediaobject>
       </figure>
 
-      <itemizedlist mark="opencircle">
-        <listitem>
-          <para><inlinemediaobject><imageobject><imagedata
-          fileref="img/background_Control_V2.png" format="PNG"/>
-          </imageobject></inlinemediaobject></para>
+      <sect1 id="sect.main_toolbar.transport_control">
+        <title>
+          Transport Control
+        </title>
+        <para><inlinemediaobject><imageobject><imagedata
+        fileref="img/background_Control_V2.png" format="PNG"/>
+        </imageobject></inlinemediaobject></para>
 
           <para>Main controls to start <emphasis role="bold">[Hotkey =
           Spacebar]</emphasis>, stop, record, fast forward, rewind, loop a song or a
           pattern.</para>
-        </listitem>
-
-        <listitem>
-          <para><inlinemediaobject><imageobject>
-          <imagedata fileref="img/background_Mode.png" format="PNG"/>
-          </imageobject></inlinemediaobject></para>
 
           <para>Set Pattern/Song Mode. When Song mode is selected Hydrogen will play 
           the complete song. This is the sequence of patterns you have created in the Song 
           Editor (see <xref linkend="chpt.song_editor"/>). When Pattern mode is selected 
           Hydrogen will play the pattern that is currently selected, and thus displayed 
-          in the Pattern Editor (see <xref linkend="chpt.pattern_editor"/>).</para>
-        </listitem>
-        
-        <listitem>
+          in the Pattern Editor (see <xref
+          linkend="chpt.pattern_editor"/>).</para>
+
+          <para>TODO: update image and fuse pattern/song mode</para>
+      </sect1>
+
+      <sect1 id="sect.main_toolbar.tap_tempo_beat_counter">
+        <title>Tap Tempo and Beat Counter</title>
           <para><inlinemediaobject><imageobject>
           <imagedata fileref="img/MeasureSettings.png" format="PNG"/>
           </imageobject></inlinemediaobject></para>
 
-          <para>Set measure type and Beat Counter (see <xref linkend="sect.tap_tempo"/>).</para>
-          
-        </listitem>
-        
-        
-
-        <listitem>
-          <para><inlinemediaobject><imageobject>
-            <imagedata fileref="img/background_BPM.png" format="PNG"/>
-          </imageobject></inlinemediaobject></para>
-
-          <para>Set speed of playing (range: 30-400 bpm) <emphasis
-          role="bold">[Hotkey = mouse wheel]</emphasis> and button to
-          enable/disable metronome</para>
-        </listitem>
-
-        <listitem>
-          <para><inlinemediaobject><imageobject>
-          <imagedata fileref="img/MidiIN_CPU.png" format="PNG"/>
-          </imageobject></inlinemediaobject></para>
-
-            <para>Shows CPU load and <abbrev>MIDI</abbrev> events.  The CPU bargraph gives you an indication of the CPU load.  The <abbrev>MIDI</abbrev> led lights up every time Hydrogen receives a midi message.</para>
-        </listitem>
-<!--
-        <listitem>
-          <para><inlinemediaobject><imageobject>
-            <imagedata fileref="img/midi_in.png" format="PNG"/>
-          </imageobject></inlinemediaobject></para>
-
-          <para>Shows MIDI events.</para>
-        </listitem>
--->
-        <listitem>
-          <para><inlinemediaobject><imageobject>
-            <imagedata fileref="img/JackTrans_Master.png" format="PNG"/>
-          </imageobject></inlinemediaobject></para>
-
-          <para>Click J. TRANS to enable <abbrev>JACK</abbrev> transport.  If the J. MASTER
-          button is pressed Hydrogen will work as <abbrev>JACK</abbrev> timebase 'master' by
-          sending additional information, like the current speed, to other <abbrev>JACK</abbrev>
-          clients. Else it will either act as 'slave' in the presence of another
-          timebase master (e.g. Ardour) or as a stand-alone client in the
-          absence of it.
-          </para>
-          <note>
-            <para>
-            Please note that when acting as 'slave' Hydrogen will obey the tempo
-            provided by the timebase master and instead of its own tempo markers
-            (see <xref linkend="chpt.preferences.audio_tab"/>).
-            </para>
-          </note>
-            
-        </listitem>
-        
-       <listitem>
-          <para><inlinemediaobject><imageobject>
-            <imagedata fileref="img/mixer-instrrack_btn.png" format="PNG"/>
-          </imageobject></inlinemediaobject></para>
-
-          <para>
-          The last section gives you quick access to the Mixer window and the Instrument Rack.
-            The LCD screen displays what Hydrogen is up to.
-          </para>
-        </listitem>        
-        
-      </itemizedlist>
-
-
-    <!--  TAP TEMPO -->
-      <sect1 id="sect.tap_tempo" xreflabel="Tap Tempo and BeatCounter">
-        <title>Tap Tempo and BeatCounter</title>
+          <para>Set measure type and Beat Counter (see <xref linkend="sect.main_toolbar.tap_tempo_beat_counter"/>).</para>
 
         <para>It is possible to change the tempo at any time using the Tap Tempo and
         BeatCounter features of Hydrogen.  You can do this while the song is playing or
@@ -1121,8 +1097,64 @@
           </para>
         </note>
 
+        <para>TODO: rework</para>
+      </sect1>
+      <sect1 id="sect.main_toolbar.bpm_control_and_metronome">
+        <title>BPM Control and Metronome</title>
+          <para><inlinemediaobject><imageobject>
+            <imagedata fileref="img/background_BPM.png" format="PNG"/>
+          </imageobject></inlinemediaobject></para>
+
+          <para>Set speed of playing (range: 30-400 bpm) <emphasis
+          role="bold">[Hotkey = mouse wheel]</emphasis> and button to
+          enable/disable metronome</para>
       </sect1>
 
+      <sect1 id="sect.main_toolbar.cpu_usage_midi_in">
+        <title>CPU Usage and MIDI in</title>
+          <para><inlinemediaobject><imageobject>
+          <imagedata fileref="img/MidiIN_CPU.png" format="PNG"/>
+          </imageobject></inlinemediaobject></para>
+
+            <para>Shows CPU load and <abbrev>MIDI</abbrev> events.  The CPU bargraph gives you an indication of the CPU load.  The <abbrev>MIDI</abbrev> led lights up every time Hydrogen receives a midi message.</para>
+      </sect1>
+      
+      <sect1 id="sect.main_toolbar.jack_control">
+        <title>JACK Control</title>
+        <para><inlinemediaobject><imageobject>
+            <imagedata fileref="img/JackTrans_Master.png" format="PNG"/>
+          </imageobject></inlinemediaobject></para>
+
+          <para>Click J. TRANS to enable <abbrev>JACK</abbrev> transport.  If the J. MASTER
+          button is pressed Hydrogen will work as <abbrev>JACK</abbrev> timebase 'master' by
+          sending additional information, like the current speed, to other <abbrev>JACK</abbrev>
+          clients. Else it will either act as 'slave' in the presence of another
+          timebase master (e.g. Ardour) or as a stand-alone client in the
+          absence of it.
+          </para>
+          <note>
+            <para>
+            Please note that when acting as 'slave' Hydrogen will obey the tempo
+            provided by the timebase master and instead of its own tempo markers
+            (see <xref linkend="chpt.preferences.audio_tab"/>).
+            </para>
+          </note>
+          <para>
+	        TODO: put all the JACK stuff in here.
+          </para>
+      </sect1>
+      
+        <sect1 id="sect.main_toolbar.gui_state">
+          <title>GUI State</title>
+          <para><inlinemediaobject><imageobject>
+            <imagedata fileref="img/mixer-instrrack_btn.png" format="PNG"/>
+          </imageobject></inlinemediaobject></para>
+
+          <para>
+          The last section gives you quick access to the Mixer window and the Instrument Rack.
+            The LCD screen displays what Hydrogen is up to.
+          </para>
+        </sect1>
     </chapter>
 
 
@@ -1149,7 +1181,7 @@
       </para>
 
      <sect1 id="chpt.song_editor.main_controls">
-      <title>Main controls</title>
+      <title>Main Controls</title>
       <para>
         <inlinemediaobject>
           <imageobject>
@@ -1249,157 +1281,9 @@
       </itemizedlist>
 
       </sect1>
-      
-      
-     <sect1 id="chpt.song_editor.tempo_and_markers">
-     <title>Tempo markers and song Tags</title>
-       <para>This section describes how you can define tempo changes and 
-       how you can add tags to your song.</para>
-       <para>The majority of songs consist of several parts (intro, verse, chorus ...) and
-       often these parts will have a different tempo.  Hydrogen provides an easy way
-       to let you change the tempo of a song at any given moment in the song.  This is 
-       done by adding Tempo change Markers to your song.</para>
-       <para>To add a Tempo change marker to your song you first need to enable the 'BPM' option
-       (the BPM button is located just above the Song editors main controls).  Once this is done
-       the horizontal bar next to the BPM button changes to a ruler with marks at every bar.
-       Now simply left-click this ruler at the bar you want the tempo to change and a
-       window will pop up where you can enter the new tempo.
-       </para>
-       <note>
-         <para>
-         Please note that the ruler will not be available while using the <abbrev>JACK</abbrev>
-         transport in 'slave' mode.
-         </para>
-       </note>
-       <para>     
-        <informalfigure id="fig.add_tempo_change">
-         <mediaobject>
-           <imageobject>
-             <imagedata fileref="img/add_tempo_change.png" format="PNG" />
-           </imageobject>
-         </mediaobject>
-         </informalfigure>
-            
-       Once you have entered the new tempo and clicked OK, the tempo change will 
-       show up on the tempo ruler.  If you click the Tempo marker again you can edit 
-       the tempo, change the bar or delete the tempo marker.
-
-        <informalfigure id="fig.tempo_bar">
-         <mediaobject>
-           <imageobject>
-             <imagedata fileref="img/tempo_bar.png" format="PNG" />
-           </imageobject>
-         </mediaobject>
-         </informalfigure>
-       </para>
-
-       <para>
-       In addition to changing the tempo when the song switches from intro > verse, 
-       it is also very handy to have a clear indication of this tempo switch (or any other
-       event in the song).  For this purpose you can also add Tags markers to the song.
-       These Tags are short text messages you can add to your song at any given 
-       moment that will be displayed whenever the song playhead passes by that Tag.</para>
-       
-       <para>
-       To add a Tag to your song simply middle-click on the song ruler (just below the 
-       tempo ruler) and a window will pop up where that allows you to add text for any bar.
-            
-        <informalfigure id="fig.add_tag">
-         <mediaobject>
-           <imageobject>
-             <imagedata fileref="img/add_tag.png" format="PNG" />
-           </imageobject>
-          </mediaobject>
-         </informalfigure>
-
-       Once you are done you will see a small blue 'T' in the song ruler for every tag 
-       you have entered.  Middle-click anywhere on the song ruler to edit the tags.
-
-         <informalfigure id="fig.tag_bar">
-          <mediaobject>
-            <imageobject>
-              <imagedata fileref="img/tag_bar.png" format="PNG" />
-            </imageobject>
-          </mediaobject>
-         </informalfigure>
-       </para>
-     </sect1>
-
-     <sect1 id="chpt.song_editor.director" xreflabel="Director">
-       <title>Director</title>
-       <para>
-         Now all we need is a way to see the tags we have entered.  This can be done
-         using the Director window.  Open the Director by pressing Alt-D, or Tools- Director :
-
-         <informalfigure id="fig.director">
-           <mediaobject>
-             <imageobject>
-               <imagedata fileref="img/screenshot-director.png" format="PNG" />
-             </imageobject>
-           </mediaobject>
-         </informalfigure>
-         
-         The Director is your best friend when you need a quick overview of what Hydrogen
-         is currently doing.  This comes in very handy when you are recording a song, or
-       if you are using Hydrogen live on stage.</para>
-       
-       <para>
-         The Director shows you the song name, a visual metronome and of course the
-         song Tags.  Just below the metronome you can see the latest tag, and below that
-         the next upcoming tag.  This way you have a nice overview of what is going on,
-         and what is about to happen in the song.
-       </para>
-     </sect1>
-
-     <sect1 id="chpt.song_editor.playbackTrack">
-		 <title>Using a playback track</title>
-		 <para>This section describes how you can use a playback track to write drums for an existing track.
-				This useful when you want to write a drumtrack to an already existing instrumental track, for example a guitar track.
-		 </para>
-		 <para>
-			To add a playback track to your song, you need to enable the playback track view. This can be done by pressing the small "P" button in the next to the vertical scroll bar of the song editor.
-
-			 <informalfigure id="fig.enablePlaybackTrack">
-				 <mediaobject>
-					 <imageobject>
-						 <imagedata fileref="img/EnablePlaybackTrack.png" format="PNG" />
-					 </imageobject>
-				 </mediaobject>
-			 </informalfigure>
-
-			 An alternative way to enable the playback track view is to enable the option "Playback track" in the "View" menu.
-
-			 If the playback track view is enabled, a visualisation of the currently loaded track is display above the song editor.
-
-			 <informalfigure id="fig.playbackTrack">
-				 <mediaobject>
-					 <imageobject>
-						 <imagedata fileref="img/PlaybackTrack.png" format="PNG" />
-					 </imageobject>
-				 </mediaobject>
-			 </informalfigure>
-
-			Left to the visualisation, the controls for the playback are displayed:
-
-			 <itemizedlist mark="opencircle">
-				 <listitem>
-				   <para><emphasis role="bold">Edit</emphasis>: load a new playback track</para>
-                 </listitem>
-                 <listitem>
-				   <para><emphasis role="bold">Mute</emphasis>: mute the current playback track</para>
-                 </listitem>
-                 <listitem>
-				   <para><emphasis role="bold">Fader</emphasis>: adjust the volume of the playback track</para>
-				 </listitem>
-			 </itemizedlist>
-
-			As an alternative to the use of the Edit Button, you can add a new playback track by drag'n'drop, just drag an audio file to the visualation area.
-			 When a playback track track is loaded, it will be played everytime Hydrogen is in "Play" mode and the song mode is activated. 
-		</para>
-	 </sect1>
 
      <sect1 id="chpt.song_editor.pattern_options">
-     <title>Patterns options</title>
+     <title>Patterns Options</title>
 
       <para>Right-clicking the name of a pattern will show you a menu 
       where you can change a number of things :</para>
@@ -1502,86 +1386,143 @@
 	        if one of the original three patterns changes, the virtual pattern automatically inherits 
         	the change. A virtual pattern can also invoke other virtual patterns.	
          </para>
-         
-          
         </listitem>        
-        
       </itemizedlist>
-        
-      
-
-
-      
-
-
-     
      </sect1>
-
-     <sect1 id="chpt.song_editor.export_song" xreflabel="Export Song">
-     <title>Exporting your song</title>
-
-      <para>Once your song is finished you can export it to an audio file.
-      This audio file can then be played on your favorite media player or imported
-      in an other audio application.</para>
-      <para>
-      To do this, go to Project - "Export song" and the following window will pop up:
-        <figure id="fig.Export_song">
-         <title>Export a song</title>
+      
+     <sect1 id="chpt.song_editor.timeline">
+     <title>Timeline</title>
+       <para>This section describes how you can define tempo changes and 
+       how you can add tags to your song.</para>
+       <sect2 id="chpt.song_editor.timeline.tempo_marker">
+         <title>Tempo Markers</title>
+       <para>The majority of songs consist of several parts (intro, verse, chorus ...) and
+       often these parts will have a different tempo.  Hydrogen provides an easy way
+       to let you change the tempo of a song at any given moment in the song.  This is 
+       done by adding Tempo change Markers to your song.</para>
+       <para>To add a Tempo change marker to your song you first need to enable the 'BPM' option
+       (the BPM button is located just above the Song editors main controls).  Once this is done
+       the horizontal bar next to the BPM button changes to a ruler with marks at every bar.
+       Now simply left-click this ruler at the bar you want the tempo to change and a
+       window will pop up where you can enter the new tempo.
+       </para>
+       <note>
+         <para>
+         Please note that the ruler will not be available while using the <abbrev>JACK</abbrev>
+         transport in 'slave' mode.
+         </para>
+       </note>
+       <para>     
+        <informalfigure id="fig.add_tempo_change">
          <mediaobject>
            <imageobject>
-             <imagedata fileref="img/Export_song.png" format="PNG" />
+             <imagedata fileref="img/add_tempo_change.png" format="PNG" />
            </imageobject>
          </mediaobject>
-        </figure>
-      To export a song you need to do 3 things:
-     
-      </para>
-      
-       <procedure>
+         </informalfigure>
+            
+       Once you have entered the new tempo and clicked OK, the tempo change will 
+       show up on the tempo ruler.  If you click the Tempo marker again you can edit 
+       the tempo, change the bar or delete the tempo marker.
 
-        <step>
-          <para>Enter a name and location for the export file in the 'Export filename' field
-          </para>
-        </step>
-        
-        <step>
-          <para>Select one of the available templates (e.g. CD, DAT ...) according to your needs:  
-          each template has a specific bitrate, resolution, and audio format (WAV, AIFF, FLAC or OGG).
-          You can tweak the selected template using the samplerate/sampledepth dropdown boxes
-          underneath the template field.
-          
-          </para>
-        </step>
-        
-        <step>
-          <para>Export mode: 'Export to a single track' will export 1 stereo downmix of your 
-          song (= the master output).  'Export to separate tracks' will create files for each 
-          instrument/track.  'Both' will create a stereo downmix + audio files for all individual
-          instruments.
-          </para>
-        </step>
-        
-        </procedure>
-        
-        <para>
-        Once all these settings have been configured all you need to do is click the 'Export'
-        button and Hydrogen will generate the requested files.
-        </para>
-
-      <note>
-       <para>
-       If you have tempo changes in your song (see <xref linkend="chpt.song_editor.tempo_and_markers"/>) 
-       these tempo changes will not be exported.  This is a know limitation of the current versions 
-       (including 0.9.6)
+        <informalfigure id="fig.tempo_bar">
+         <mediaobject>
+           <imageobject>
+             <imagedata fileref="img/tempo_bar.png" format="PNG" />
+           </imageobject>
+         </mediaobject>
+         </informalfigure>
        </para>
-       <para>
-       As a workaround you can record the output of Hydrogen with an audio recording
-       application (like Ardour, Qtractor ...)
-       </para>
-      </note>
 
+       <para>
+       In addition to changing the tempo when the song switches from intro > verse, 
+       it is also very handy to have a clear indication of this tempo switch (or any other
+       event in the song).  For this purpose you can also add Tags markers to the song.
+       These Tags are short text messages you can add to your song at any given 
+       moment that will be displayed whenever the song playhead passes by that Tag.</para>
+       </sect2>
+       
+       <sect2 id="chpt.song_editor.timeline.tag">
+         <title>Tags</title>       
+       <para>
+       To add a Tag to your song simply middle-click on the song ruler (just below the 
+       tempo ruler) and a window will pop up where that allows you to add text for any bar.
+            
+        <informalfigure id="fig.add_tag">
+         <mediaobject>
+           <imageobject>
+             <imagedata fileref="img/add_tag.png" format="PNG" />
+           </imageobject>
+          </mediaobject>
+         </informalfigure>
+
+       Once you are done you will see a small blue 'T' in the song ruler for every tag 
+       you have entered.  Middle-click anywhere on the song ruler to edit the tags.
+
+         <informalfigure id="fig.tag_bar">
+          <mediaobject>
+            <imageobject>
+              <imagedata fileref="img/tag_bar.png" format="PNG" />
+            </imageobject>
+          </mediaobject>
+         </informalfigure>
+       </para>
+       </sect2>
      </sect1>
-    </chapter>
+
+     <sect1 id="chpt.song_editor.playbackTrack">
+		 <title>Playback Track</title>
+		 <para>This section describes how you can use a playback track to write drums for an existing track.
+				This useful when you want to write a drumtrack to an already existing instrumental track, for example a guitar track.
+		 </para>
+		 <para>
+			To add a playback track to your song, you need to enable the playback track view. This can be done by pressing the small "P" button in the next to the vertical scroll bar of the song editor.
+
+			 <informalfigure id="fig.enablePlaybackTrack">
+				 <mediaobject>
+					 <imageobject>
+						 <imagedata fileref="img/EnablePlaybackTrack.png" format="PNG" />
+					 </imageobject>
+				 </mediaobject>
+			 </informalfigure>
+
+			 An alternative way to enable the playback track view is to enable the option "Playback track" in the "View" menu.
+
+			 If the playback track view is enabled, a visualisation of the currently loaded track is display above the song editor.
+
+			 <informalfigure id="fig.playbackTrack">
+				 <mediaobject>
+					 <imageobject>
+						 <imagedata fileref="img/PlaybackTrack.png" format="PNG" />
+					 </imageobject>
+				 </mediaobject>
+			 </informalfigure>
+
+			Left to the visualisation, the controls for the playback are displayed:
+
+			 <itemizedlist mark="opencircle">
+				 <listitem>
+				   <para><emphasis role="bold">Edit</emphasis>: load a new playback track</para>
+                 </listitem>
+                 <listitem>
+				   <para><emphasis role="bold">Mute</emphasis>: mute the current playback track</para>
+                 </listitem>
+                 <listitem>
+				   <para><emphasis role="bold">Fader</emphasis>: adjust the volume of the playback track</para>
+				 </listitem>
+			 </itemizedlist>
+
+			As an alternative to the use of the Edit Button, you can add a new playback track by drag'n'drop, just drag an audio file to the visualation area.
+			 When a playback track track is loaded, it will be played everytime Hydrogen is in "Play" mode and the song mode is activated. 
+		</para>
+	 </sect1>
+     <sect1 id="sect.song_editor.automation_path">
+	   <title>Automation Path</title>
+       <para>
+	     TODO
+       </para>
+     </sect1>
+   </chapter>
     
 
 <!--  PATTERN EDITOR  -->
@@ -1611,7 +1552,7 @@
       
       <para>First let's take a look at the (classic) 'Drum' mode :
         <figure id="fig.PatternEditor_DrumMode">
-         <title>Pattern Editor in Drum mode</title>
+         <title>Pattern Editor in Drum Mode</title>
          <mediaobject>
            <imageobject>
              <imagedata fileref="img/PatternEditor_DrumMode.png" format="PNG" />
@@ -1622,7 +1563,7 @@
       
       <sect1 id="chpt.pattern_editor.controls"> 
        
-        <title>Pattern Editor Controls</title>
+        <title>Controls</title>
         <para>The top part of the pattern editor contains a number of controls :</para>
       
         <figure id="fig.PatternEditorControls">
@@ -1709,7 +1650,7 @@
       </sect1>
       
       <sect1 id="chpt.pattern_editor.drumkit">
-      <title>Pattern Editor Drumkit</title>
+      <title>Drumkit Editor</title>
         <para>The section on the left shows you what drumkit is currently selected (GMkit by default) and below that you can see
         the instruments that are part of this kit.</para>
         
@@ -1785,7 +1726,7 @@
       </sect1>
 
       <sect1 id="chpt.pattern_editor.sequence_area">
-      <title>Pattern Editor Sequence area</title>
+      <title>Sequence Area</title>
         <para>This is where it all happens, this is where you can make music :-)</para>
         <para>In this area you can see your selected pattern and add notes for any instrument. 
         The simplest way to create a pattern is by adding notes using your mouse 
@@ -1866,7 +1807,7 @@
       </sect1>
       
       <sect1 id="chpt.pattern_editor.note_properties">
-      <title>Pattern Editor Note Properties</title>
+      <title>Note Properties Editor</title>
       <para>Clicking on an instrument or adding/removing a note next to it 
       will select this instrument.  Once an instrument is selected the note properties 
       for this instrument will be shown in the form of vertical lines in the bottom window.  
@@ -1999,14 +1940,14 @@
       </sect1>
 
       <sect1 id="chpt.pattern_editor.piano_mode">
-      <title>Pattern Editor Piano mode</title>
+      <title>Piano Mode Editor</title>
       <para>Drum mode (see <xref linkend="fig.PatternEditor_DrumMode"/>) focuses on using Hydrogen as a drum machine.
       If you are using Hydrogen as an instrument there is a big chance that the Piano mode is for you.
       It gives you a complete 'piano keyboard' so you can easily put down your tunes.</para>
       <para>You can compare the Piano mode to the Note properties Notekey (described above), only here you have a 
       complete piano keyboard, so you don't have to select the octave first.</para>
        <figure id="fig.PatternEditor_PianoMode">
-         <title>Pattern Editor in Piano mode</title>
+         <title>Pattern Editor in Piano Mode</title>
          <mediaobject>
            <imageobject>
              <imagedata fileref="img/PatternEditor_PianoMode.png" format="PNG" />
@@ -2017,376 +1958,12 @@
      
     </chapter>
 
-
-<!-- MIXER -->
-    <chapter id="chpt.mixer" xreflabel="Mixer">
-      <title>Mixer</title>
-
-      <para>The Mixer window can be opened by pressing Alt+M, by clicking 
-      Mixer in the Tools menu, or by clicking the Mixer button on the main toolbar.
-      </para>
-      <para>The Mixer consists of 3 sections (left>right) : the instrument channel strips, 
-      the FX plugin rack and the master fader section.  The Hydrogen Mixer works very
-       much like a hardware mixer does : it lets you set the volume, pan, FX and several 
-       other things for every instrument.
-
-      <figure id="fig.mixer">
-        <title>The Mixer</title>
-        <mediaobject>
-          <imageobject>
-            <imagedata fileref="img/Mixer.png" format="PNG" />
-          </imageobject>
-        </mediaobject>
-      </figure>
-      </para>
-
-    <sect1 id="chpt.mixer.channel_strips">
-      <title>Instrument channel strips</title>
-       <para>From top to bottom : the 2 top elements on the strip are a 'play' button / 'trig' led combination.
-            (
-      <inlinemediaobject>
-        <imageobject>
-          <imagedata fileref="img/btn_play_on_mixer.png" format="PNG" />
-        </imageobject>
-      </inlinemediaobject>
-       )
-         The play button lets you trigger the instrument at maximum velocity (handy for checking clipping), 
-       and the trig led lights up whenever this instrument is triggered (from the song sequence, 
-       or by an external midi controller).  Right of this button/led you will find another led that shows
-       you what instrument is currently selected.  This is also the instrument that is selected in the pattern editor.
-       As soon as you change one of the settings of a channel strip the instrument will be selected.</para>
-
-       <para>Just below you can find the Mute
-       
-       <inlinemediaobject>
-        <imageobject>
-          <imagedata fileref="img/btn_mute_on.png" format="PNG" />
-        </imageobject>
-       </inlinemediaobject>
-      
-        and Solo
-        
-       <inlinemediaobject>
-        <imageobject>
-          <imagedata fileref="img/btn_solo_on.png" format="PNG" />
-        </imageobject>
-       </inlinemediaobject>       
-
-       buttons and the Pan(orama) knob.
-       </para>
-       <note>
-         <para>
-           Note that the Mute and Solo states are also reflected in the Song editor.
-         </para>
-       </note>
-
-      <para>
-      Next are 4 pre-fader FX send knobs that determine how much of this instrument will be sent to
-      the effect plugins in the FX rack.
-      
-        <informalfigure id="fig.FX_send_knobs">
-         <mediaobject>
-           <imageobject>
-             <imagedata fileref="img/FX_send_knobs.png" format="PNG" />
-           </imageobject>
-         </mediaobject>
-         </informalfigure>
-      
-      
-      
-      Just below that you can find an LCD peak-value display,
-      and finally the volume fader and VU meter for that instrument.</para>
-      <para><emphasis role="bold">IMPORTANT NOTE</emphasis> : keep in mind that the volume and pan settings that you
-      find on the Mixer are global settings.  The per-note velocity and pan settings in the Pattern editor
-      are settings that are relative to the settings in the Mixer window !</para>
-
-
-    </sect1>
-    
-    <sect1 id="sect.fx_rack_LADSPA">
-      <title>FX rack and LADSPA plugins</title>
-       <para>The FX rack has 4 bays where you can load a LADSPA effect plugin, but before
-        you can load any plugins these must be installed (surprised ?  ;-)</para>
-        <para>There are dozens of plugins available for download from various sources :
-
-      <itemizedlist>
-        <listitem>
-          <para><emphasis role="bold"><abbrev>SWH</abbrev>-Plugins</emphasis>: available at <ulink
-          url="http://plugin.org.uk">http://plugin.org.uk</ulink>. </para>
-          <note>
-            <para>If you want to compile these plugins
-          you need the <application>FFTW</application> tarball from <ulink
-          url="http://www.fftw.org">http://www.fftw.org</ulink>)
-            </para>
-          </note>
-        </listitem>
-
-        <listitem>
-          <para><emphasis role="bold"><abbrev>CMT</abbrev></emphasis>: available at <ulink url="http://www.ladspa.org">http://www.ladspa.org</ulink>.</para>
-        </listitem>
-
-        <listitem>
-          <para><emphasis role="bold"><abbrev>TAP</abbrev></emphasis>: available at <ulink url="http://tap-plugins.sf.net">http://tap-plugins.sf.net</ulink>.</para>
-        </listitem>
-
-        <listitem>
-          <para><emphasis role="bold">Calf plugins</emphasis>: available at <ulink url="http://calf.sourceforge.net/">http://calf.sourceforge.net/</ulink>.</para>
-        </listitem>
-
-        <listitem>
-          <para><emphasis role="bold"><abbrev>LSP</abbrev> plugins</emphasis>: available at <ulink url="https://github.com/sadko4u/lsp-plugins/">https://github.com/sadko4u/lsp-plugins/</ulink>.</para>
-        </listitem>
-
-        <listitem>
-          <para> ....</para>
-        </listitem>
-
-      </itemizedlist>
-      </para>
-      
-      <warning>
-        <title>Plugins Kill</title>
-        <para>A badly designed <abbrev>LADSPA</abbrev> plugin is capable of
-        hanging, crashing, freezing, screeching, overflowing buffers, and even
-        phoning home.  If you start having issues with Hydrogen, disable your
-        plugins and see if things improve.  Some plugins are not designed for
-        real-time use, and some are just plain better than others.</para>
-      </warning>
-
-      <para>Once you have installed some plugins you can select one by clicking the
-      
-
-      <inlinemediaobject>
-        <imageobject>
-          <imagedata fileref="img/edit_off.png" format="PNG" />
-        </imageobject>
-      </inlinemediaobject>
-
-      button.  (if you do not see the FX rack, make sure that the 
-
-      <inlinemediaobject>
-        <imageobject>
-          <imagedata fileref="img/showFX_on.png" format="PNG" />
-        </imageobject>
-      </inlinemediaobject>
-
-      button (in the Master section) is enabled)</para>
-      <para>Now the FX selector window will pop up :
-      
-      <figure id="fig.select_effect">
-        <title>Select an Effect</title>
-        <mediaobject>
-          <imageobject>
-            <imagedata fileref="img/MixerFXSelect.png" format="PNG" />
-          </imageobject>
-        </mediaobject>
-      </figure>
-      
-      Once you have selected a plugin you will immediately have access 
-      to its parameters:
-      
-       
-        <informalfigure id="figLADSPA_FX_Properties">
-         <mediaobject>
-           <imageobject>
-             <imagedata fileref="img/LADSPA_FX_Properties.png" format="PNG" />
-           </imageobject>
-         </mediaobject>
-         </informalfigure>
-
-
-      You can select another plugin by clicking the 'Select FX' button. If you quickly want to 
-      enable/disable the effect click the 'Deactivate' button (or the Bypass (
-
-      <inlinemediaobject>
-        <imageobject>
-          <imagedata fileref="img/bypass_over.png" format="PNG" />
-        </imageobject>
-        </inlinemediaobject>)
-
-      button in the FX rack).  This can be handy for a quick A/B comparison.</para>
-      
-      <para>After you have selected the FX and tweaked it's parameters you can use the 
-      FX return knob to increase/decrease how much of this FX will be returned to the master output.</para>
-
-    </sect1>
-     
-    <sect1 id="sect.master">
-      <title>Master section</title>
-       <para>
-       
-      The Master section contains the Master volume fader with VU meters and three global Humanize 
-      settings for Velocity, Timing and Swing (in order to add a 'human feel' to the song):
-      
-     <itemizedlist>
-        <listitem>
-          <para><emphasis role="bold">Velocity</emphasis>: adds a certain randomness to the note velocity. 
-           The higher you turn this knob, the more the velocity will be randomized.
-          </para>
-        </listitem>
-
-        <listitem>
-          <para><emphasis role="bold">Timing</emphasis>: adds a certain randomness to the note timing (lead/lag).  
-            The higher you turn this knob, the more the timing will be randomized.
-          </para>
-          <note><para>Notes are displaced in time (using Gaussian perturbation)
-            but the pattern durations or bpm do not change.</para>
-          </note>
-          
-        </listitem>
-        
-       <listitem>
-          <para><emphasis role="bold">Swing</emphasis>: this knob will add a certain amount of swing to the song.</para>
-          <note> <para> Swing (a slight time delay) is applied to upbeat 16th-notes,
-          and not to 8th-notes as it happens in traditional Jazz.</para> </note>
-        </listitem>        
-        
-     </itemizedlist>
-       </para>
-       <note>
-         <para>
-      Note that Hydrogen can also be switched to 'per instrument output' mode (see <xref linkend="chpt.preferences.audio_tab"/>),
-      and in this mode all channel strip outputs will be available in <abbrev>JACK</abbrev> (not just the Master output).  
-      This allows you to route the individual instruments directly into any other <abbrev>JACK</abbrev> enabled application (eg Ardour) and gives you
-      a lot more flexibility.
-         </para>
-       </note>
-      
-      <para>On the bottom-right of the Master section the 'FX' button 
-        <inlinemediaobject>
-          <imageobject>
-            <imagedata fileref="img/showFX_on.png" format="PNG" />
-          </imageobject>
-        </inlinemediaobject>      
-        will show/hide the FX rack, and the 'Peak' button 
-       
-      <inlinemediaobject>
-        <imageobject>
-          <imagedata fileref="img/showPeaks_on.png" format="PNG" />
-        </imageobject>
-      </inlinemediaobject>       
-       will enable/disable the VU meters.
-       
-       <note>
-       <para>The VU meter fall off speed can be configured in the preferences window (see <xref linkend="chpt.preferences.appearance_tab"/>)</para>
-       </note>
-       
-      </para>
-  
-      <para>  In the upper part of Master section there is a small "cog" icon button:</para>
-
-        <informalfigure id="mixerSettingsButton">
-         <mediaobject>
-           <imageobject>
-             <imagedata fileref="img/mixerSettingsButton.png" format="PNG" />
-           </imageobject>
-         </mediaobject>
-         </informalfigure>
-         <para>
-
-         Click it to open the Mixer Settings window:
-
-         <informalfigure id="mixerSettingsDialog">
-         <mediaobject>
-           <imageobject>
-             <imagedata fileref="img/mixerSettingsDialog.png" format="PNG" />
-           </imageobject>
-         </mediaobject>
-         </informalfigure>
-          Here you can select the <emphasis role="bold">Pan Law</emphasis> used by Hydrogen Mixer.
-          </para>
-         <para>
-             The Pan Law is the relationship between the pan knob and the separate gains of Left and Right outputs.
-             The aim is to control the horizontal angle the sound seems to arrive from.
-         </para>
-         <para>
-            Hydrogen features one the most customizable and accurate Pan Law set. </para>
-            
-          <para>
-             You will find four categories: <emphasis>linear</emphasis>, <emphasis>polar</emphasis>,
-             <emphasis>ratio</emphasis>, <emphasis>quadratic</emphasis>.
-             Every category gives a different "scale" or "sensibility" to the pan knob:
-              the same knob position will make the sound appear more lateral or central depending on the category,
-              from the most lateral (<emphasis>linear</emphasis>) to the most central (<emphasis>quadratic</emphasis>).
-         </para>
-         
-         <para>
-           Then for each category you will find four options, that define a <emphasis>constraint</emphasis> between the
-            gains of the two channels:     
-           <itemizedlist>
-                <listitem>
-                  <para><emphasis role="bold">Balance Law (0dB)</emphasis>: 
-                  when you turn the pan knob from center to right, the right gain stays constant at maximum level
-                   while the left gain decreases from the maximum level to 0 (and symmetrically turning from center to left). </para>
-                    <para>It is ideal for balancing a DUAL-channel track. It has ZERO center compensation: the sound 
-                    will be <emphasis>louder</emphasis> when the pan knob is at <emphasis>center</emphasis> -
-                    unless channels are out of phase - so you may have to readjust the volume manually with the
-                     mixer fader.
-                  </para>
-                </listitem>
-                
-                <listitem>
-                  <para> <emphasis role="bold">Constant Power (-3dB)</emphasis>: the total <emphasis>power</emphasis>
-                   (which is proportional to the <emphasis>square</emphasis> of the gain) is constant for any position
-                    of the pan knob. </para>
-                    <para>Compared to the Balance Law, each channel gain is divided by the square root of 2
-                    when the pan knob is at center (-3.0103 dB center compensation).
-                    In a common room, this constraint <emphasis>may</emphasis> give the general perception of uniform
-                     volume for any pan knob position (panning a MONO track).
-                  </para>
-                </listitem>
-                
-                <listitem>
-                  <para> <emphasis role="bold">Constant Sum (-6dB)</emphasis>: the sum of left and right gains is
-                   constant for any position of the pan knob. </para>
-                     <para>This constraint preserves the mix volumes in mono export.
-                     Compared to the Balance Law, each channel gain is halved (-6.0206 dB) when the pan knob
-                      is at center.
-                     If you are in an ideal anechoic room (where there are no acoustic reflections)
-                     and you seat perfectly at the same distance from the speakers,
-                     with this constraint the volume will be really constant for any pan position, because of the linear
-                     <emphasis>super-position</emphasis> of sound waves (panning a MONO track).
-                  </para>
-                </listitem>
-
-               <listitem>
-                  <para><emphasis role="bold">Constant k-Norm (Custom dB center compensation)</emphasis>:
-                   you can experiment adjusting the center compensation to your
-                  taste! </para>
-                  <note>
-                    <para>Note that some hi-end studio mixers - to be used in well tuned rooms -
-                    have center compensation between -3dB and -6dB.
-                    </para>
-                  </note>
-                </listitem>
-             </itemizedlist>
-             </para>
-
-          <para>The four constraints should not change the perception of the <emphasis>stereo angle</emphasis>,
-          but the <emphasis>volume</emphasis> only (depending on the pan knob).
-         </para>
-         <para>
-          The Pan Law is something you should choose <emphasis>before</emphasis> starting the mix and keep untouched.
-           Hydrogen sets the <emphasis>ratio Balance Law</emphasis> by default because it was the only available law
-            until version 1.0 (so old songs and drumkits will sound the same).
-          The setting is saved in the songfile but not in preferences, 
-          so it is NOT remembered when you create a new song.
-         </para>
-       <note>
-       <para>Unlike in advanced mixers, Hydrogen panning makes no distinction if a track is mono or dual-channel (stereo).
-       You cannot pan each channel of stereo tracks separately, nor use a balance law for them and another
-       pan law for mono tracks.
-        If the drumkit you are using is made of true stereo samples, you don't want a negative center compensation
-         probably, so you should select a Balance Law.</para>
-       </note>
-
-
-    </sect1>
-    
-  </chapter>
   <chapter id="chpt.sound_library" xreflabel="Instrument rack">
     <title>Sound Library (Drumkit/Pattern/Song Manager)</title>
 
+    <para>
+	  TODO: split into conceptual part and one that deals with the actual user interface
+    </para>
       <para>First of all a little history on the Sound library and Drumkits. Hydrogen began as a 
       dedicated drum machine but has evolved into a versatile sound synthesizer/sequencer 
       that is capable of generating and manipulating all sorts of sounds. Hence the original 
@@ -2398,7 +1975,7 @@
       frequently mean the same thing, but not always. The diagram below shows the actual 
       relation between the Soundlibrary and Drumkits:
       <figure id="fig.SoundlibraryHierarchy">
-         <title>Soundlibrary/Drumkit hierarchy</title>
+         <title>Soundlibrary/Drumkit Hierarchy</title>
          <mediaobject>
            <imageobject>
              <imagedata fileref="img/SoundlibraryHierarchy_V4.png" format="PNG" />
@@ -2465,25 +2042,15 @@
         library</guimenuitem></menuchoice>.</para>
 
         <para>
-        You can import existing drumkits from other users via <menuchoice>
-        <guimenu>Instruments</guimenu><guimenuitem>Import library</guimenuitem>
-        </menuchoice>.  The Import window will pop up with the Internet tab selected.
-        By default the link to the drumkit list (on hydrogen-music.org) will be filled in, 
-        and after pressing the 'Update list' button you will get a complete list of all
-        drumkits that are available for download.  In the status column you can see
-        if a kit is installed or not.
-
-       <figure id="fig.import_drumkit">
-         <title>Import Drumkit</title>
-         <mediaobject>
-           <imageobject>
-             <imagedata fileref="img/Sound_Library_import.png" format="PNG" />
-           </imageobject>
-         </mediaobject>
-       </figure>
-  
+	      TODO: reference to sect.main_form.import_drumkit
+        </para>
+        
+        <para>
         If you select one of the drumkits you will see info about this kit in the right
-        pane of the Import window: name, description, author and also the license type.
+        pane of the Import window: name, description, author and also the
+        license type.
+        </para>
+        
 
        <warning>
        <para>If you are using Hydrogen for commercial purposes, (creating songs and 
@@ -2504,8 +2071,10 @@
        
        </warning>
 
-    
-       You can install a drumkit by selecting it and clicking 'Download and Install'.
+
+       <para>
+         You can install a drumkit by selecting it and clicking 'Download and Install'.
+         
     
        <informalfigure id="fig.downloading_soundlibrary">
          <mediaobject>
@@ -2550,16 +2119,19 @@
     </chapter>
 
     <chapter id="chpt.instrument_editing">
-      <title>Drumkits and Instrument Editing</title>
+      <title>Instrument and Drumkits Editor</title>
 
-
-      
-      <!-- Need to add an explanation of what the instrument list
-           and instrument editor are. -->
+      <para>
+	    TODO: disentangle this chapter into a plain description of the "General" and "Layers" view of the Instrument Editor and split of the "Create a New Drumkit" tutorial and put it in the examples
+      </para>
 
       <sect1 id="chpt.instrument_editing.concepts">
         <title>Concepts</title>
 
+        <para>
+	      TODO: do we needs this or are links to the glossary sufficient?
+        </para>
+        
         <para>
           The synthesizer in Hydrogen is a sample-based synthesizer.  A sample
           is a piece of pre-recorded audio (usually between 0.1 sec and 3 sec).
@@ -2635,87 +2207,9 @@
           movies, and famous people speaking.  Be creative!
         </para>
 
-      </sect1>
-      <sect1 id="chpt.instrument_editing.new_kit">
-       <title>Creating a New Drumkit</title>
-       <para>In the next paragraphs we will show you how to create a complete drumkit.  
-       Keeping in mind the 'Soundlibrary hierarchy' (see <xref linkend="fig.SoundlibraryHierarchy"/>)
-       we will use a top-down approach, so we will start at the Drumkit level and work our way 
-       down to the samples.</para> 
-        
-       <para>Creating a new drumkit with Hydrogen is done with the Instrument
-       Editor.  You can load samples, set envelope
-       parameters, set the gain, and other advanced features like mute
-       groups, a low-pass resonance filter, and pitch randomization.</para>
-
-       <para>TIP : Instead of creating your own drumkit, you can also use or download
-       existing drumkits using the <xref linkend="chpt.sound_library"/>.</para>
-
-        <para>Lets make a  brand new drum kit :</para>
-        <procedure>
-          <step><para>select
-          <menuchoice>
-            <guimenu>Instruments</guimenu>
-            <guimenuitem>"Clear All"</guimenuitem>
-          </menuchoice>
-
-          .  This will give you a bank of 32 blank instruments.  To delete
-          instruments, right-click on on each instrument and select
-          "<guimenuitem>Delete Instrument</guimenuitem>".  To add more instruments,
-          select
-
-          <menuchoice>
-            <guimenu>Instruments</guimenu>
-            <guimenuitem>"Add instrument"</guimenuitem>
-          </menuchoice>
-          .</para>
-          </step>
-
-
-          <step>
-          <para>Select an instrument to start editing it.  This is done by
-          left-clicking on the name of the instrument in the instrument list (at
-          the left).  You will notice that the name of the instrument in the
-          Instrument Editor matches the one that you clicked.</para>
-          </step>
-         
-          <step>
-          <para>Once you have your drum kit working the way you want, select
-
-          <menuchoice>
-            <guimenuitem>Instruments</guimenuitem>
-            <guimenuitem>"Save library"</guimenuitem>
-          </menuchoice>
-
-          .  You will be prompted for the name of the kit to save.  If you wish to
-          <emphasis>overwrite</emphasis> an existing kit, you will need to type in
-          the same name as the kit that you want to replace.</para>
-         </step>
-
-         <step>
-          <para>Drumkits are automatically stored in the <filename
-          class="directory">data</filename> directory (i.e. <filename
-          class="directory">$HOME/.hydrogen/data/drumkits</filename>).</para>
-         </step>
-
-         <step>
-          <para>To export a drumkit (for sharing with others), it must first be
-          loaded into your Sound Library.  Then, select
-
-          <menuchoice>
-            <guimenuitem>Instruments</guimenuitem>
-            <guimenuitem>"Export library"</guimenuitem>
-          </menuchoice>
-
-          from the menu.  Select the drum kit that you wish to export, and give it
-          a file name to save it to.</para>
-          </step>
-        </procedure>
-
-      </sect1>
-      
-      <sect1 id="chpt.instrument_editing.parameters">
-        <title>Instrument Parameters</title>
+      </sect1>      
+      <sect1 id="chpt.instrument_editor.general">
+        <title>General</title>
 
         <para>In the instrument editor, click on the
         <guibutton>General</guibutton> button.  Here you can adjust several
@@ -2907,7 +2401,7 @@
         </sect2>  
 
         <sect2 id="chpt.instrument_editing.filter">
-          <title>Filter parameters</title>
+          <title>Filter Parameters</title>
 
           <para>The filter is a low-pass resonance filter.  If you don't wish to
           use is, click the <guibutton>BYP</guibutton>ass button so that it's
@@ -2938,7 +2432,7 @@
         </sect2>
         
         <sect2 id="chpt.instrument_editing.pitch_shift_parameters">
-          <title>Pitch Shift parameters</title>
+          <title>Pitch Shift Parameters</title>
           <para> The first two knobs control the pitch shift offset.
                  You can use it to change the tuning of the instrument.
                 "Pitch" is the Coarse control and has quantized steps of half-tones from -24 to +24.
@@ -2954,7 +2448,7 @@
         
 
         <sect2 id="chpt.instrument_editing.midi_out_settings">
-          <title>MIDI out settings</title>
+          <title>MIDI Out Settings</title>
 
           <para>Hydrogen is capable of generating midi messages that you can use
           to trigger any external midi device or application.  To do this you
@@ -2995,8 +2489,8 @@
       </sect1>
       
       
-      <sect1 id="chpt.instrument_editing.new_instrument">
-        <title>Creating an Instrument and Layers</title>
+      <sect1 id="chpt.instrument_editor.layers">
+        <title>Layers</title>
 
         <para>For each instrument in a drum kit, you can load several samples
         and set different synthesizer parameters.  This section will step you
@@ -3043,7 +2537,7 @@
         a curtain).  You will now see Layer 2 appear.</para>
         
         <figure id="instrumenteditor.layers">
-        <title>The Instrument editor Layers view</title>
+        <title>The Instrument Editor Layers View</title>
         <mediaobject>
           <imageobject>
             <imagedata fileref="img/Instrument_Layers.png" format="PNG" />
@@ -3095,13 +2589,13 @@
           slower.  This is called the Doppler Effect.  So, if you have a
           1-second sample that you turn down -12 (1 octave), your sample will
           only last for 0.5-seconds.  If you do not want this to happen you should
-          use rubberband instead (see <xref linkend="sect.layer_editing.section2"/>)</para>
+          use rubberband instead (see <xref linkend="chpt.sample_editor.section2"/>)</para>
         </note>
 
         <para>You can hear the sample in a layer by clicking the layer id (just 
         below the 'General' and 'Layers' buttons) and the 'Delete Layer' button 
         will delete the currently selected layer.</para>
-        <sect2 id="chpt.instrument_editing.new_instrument.sample_selection">
+        <sect2 id="chpt.instrument_editor.layers.sample_selection">
           <title>Sample Selection</title>
             <para>
                 Certain set of samples contain different sample versions of the same sound for the same note/velocity
@@ -3141,9 +2635,21 @@
             </itemizedlist>
         </sect2>
       </sect1>
+      
+    </chapter>
 
-      <sect1 id="sect.layer_editing">
-        <title>Sample Editor</title>
+    
+      <chapter id="chpt.sample_editor">
+        <title>Sample Editor</title>        
+        <figure id="sample.editor">
+        <title>The Sample Editor</title>
+        <mediaobject>
+          <imageobject>
+            <imagedata fileref="img/SampleEditor_V5.png" format="PNG" />
+          </imageobject>
+        </mediaobject>
+        </figure>        
+
         <para>So far we have created a multilayered Drumkit, set a number of 
         instrument parameters, played with velocity settings and so on.  Now it's 
         time to go one step deeper and edit the samples using one of the newest
@@ -3166,19 +2672,10 @@
         settings.</para>
         </note>
         
-        <figure id="sample.editor">
-        <title>The Sample Editor</title>
-        <mediaobject>
-          <imageobject>
-            <imagedata fileref="img/SampleEditor_V5.png" format="PNG" />
-          </imageobject>
-        </mediaobject>
-        </figure>        
-        
         <para>The Sample Editor consists of 3 sections (as indicated in the figure above):</para>
        
-        <sect2 id="sect.layer_editing.section1">
-        <title>Sample Editor in/out points</title>
+        <sect1 id="chpt.sample_editor.section1">
+        <title>In/Out Points</title>
         <para>
         In this section you can set the start, stop and loop points for the sample by dragging the 
         the 3 markers:
@@ -3210,10 +2707,10 @@
         <para>If you want to hear a preview of the tweaking you have done so far, you first need to
         press the 'Apply Changes' button (@ the bottom of section 3) and then the Play button to
         hear the result.</para>
-        </sect2>
+        </sect1>
         
-        <sect2 id="sect.layer_editing.section2">
-        <title>Sample Editor rubberband</title>
+        <sect1 id="chpt.sample_editor.section2">
+        <title>Rubberband</title>
         <para>This section of the Sample Editor allows you to control the Rubberband settings.
         Rubberband is a tool that can change the tempo of a sample without changing 
         the sample's pitch (and vice versa).</para>
@@ -3253,11 +2750,11 @@
         <para><emphasis role="bold">Note</emphasis>: If you want Hydrogen to recalculate the sample length on the fly (using rubberband)
         you must enable the 'RUB' button (see figure above).</para>
         
-        </sect2>
+        </sect1>
         
         
-        <sect2 id="sect.layer_editing.section3">
-        <title>Sample Editor volume/pan</title>
+        <sect1 id="chpt.sample_editor.section3">
+        <title>Volume and Pan</title>
         <para>In the bottom section of the Sample Editor you can see the end result 
         of the tweaks you have made by pressing the Apply Changes button.  You can
         also change the the Volume and Panorama (Pan) of your sample here.
@@ -3268,70 +2765,411 @@
         Left clicking in the bottom window will ad a node to an envelope and also 
         allows you to drag an existing node.  Right-clicking a node will delete it. 
         Don't forget to Apply Changes before you play your tweaked sample.</para>
-        </sect2>
+        </sect1>
         
-      </sect1>
+      </chapter>
+
+    <chapter id="chpt.mixer" xreflabel="Mixer">
+      <title>Mixer</title>
+
+      <para>The Mixer window can be opened by pressing Alt+M, by clicking 
+      Mixer in the Tools menu, or by clicking the Mixer button on the main toolbar.
+      </para>
+      <para>The Mixer consists of 3 sections (left>right) : the instrument channel strips, 
+      the FX plugin rack and the master fader section.  The Hydrogen Mixer works very
+       much like a hardware mixer does : it lets you set the volume, pan, FX and several 
+       other things for every instrument.
+
+      <figure id="fig.mixer">
+        <title>The Mixer</title>
+        <mediaobject>
+          <imageobject>
+            <imagedata fileref="img/Mixer.png" format="PNG" />
+          </imageobject>
+        </mediaobject>
+      </figure>
+      </para>
+
+    <sect1 id="chpt.mixer.channel_strips">
+      <title>Instrument Channel Strips</title>
+       <para>From top to bottom : the 2 top elements on the strip are a 'play' button / 'trig' led combination.
+            (
+      <inlinemediaobject>
+        <imageobject>
+          <imagedata fileref="img/btn_play_on_mixer.png" format="PNG" />
+        </imageobject>
+      </inlinemediaobject>
+       )
+         The play button lets you trigger the instrument at maximum velocity (handy for checking clipping), 
+       and the trig led lights up whenever this instrument is triggered (from the song sequence, 
+       or by an external midi controller).  Right of this button/led you will find another led that shows
+       you what instrument is currently selected.  This is also the instrument that is selected in the pattern editor.
+       As soon as you change one of the settings of a channel strip the instrument will be selected.</para>
+
+       <para>Just below you can find the Mute
+       
+       <inlinemediaobject>
+        <imageobject>
+          <imagedata fileref="img/btn_mute_on.png" format="PNG" />
+        </imageobject>
+       </inlinemediaobject>
       
-      <sect1 id="chpt.instrument_editing.tips">
-        <title>Tips on Editing Instruments</title>
+        and Solo
+        
+       <inlinemediaobject>
+        <imageobject>
+          <imagedata fileref="img/btn_solo_on.png" format="PNG" />
+        </imageobject>
+       </inlinemediaobject>       
 
-        <para>With all of the different parameters available to tweak, it can be
-        difficult to set up something that sounds nice when you're done.  Here are 
-        a few tips on setting up an instrument:</para>
+       buttons and the Pan(orama) knob.
+       </para>
+       <note>
+         <para>
+           Note that the Mute and Solo states are also reflected in the Song editor.
+         </para>
+       </note>
 
-        <para><emphasis role="bold">Turn down the gain.</emphasis> Every gain
-        knob (i.e. an amplifier), this is a <emphasis>gain stage</emphasis>.  
-        With every gain stage you have, it's
-        easy to overdrive your signal &mdash; which means the signal gets
-        distorted by clipping.  In addition, if you have two samples that, by
-        themselves, peg your meters &mdash; what do you think happens when you
-        combine them?  That's right, you overdrive the signal again.</para>
+      <para>
+      Next are 4 pre-fader FX send knobs that determine how much of this instrument will be sent to
+      the effect plugins in the FX rack.
+      
+        <informalfigure id="fig.FX_send_knobs">
+         <mediaobject>
+           <imageobject>
+             <imagedata fileref="img/FX_send_knobs.png" format="PNG" />
+           </imageobject>
+         </mediaobject>
+         </informalfigure>
+      
+      
+      
+      Just below that you can find an LCD peak-value display,
+      and finally the volume fader and VU meter for that instrument.</para>
+      <para><emphasis role="bold">IMPORTANT NOTE</emphasis> : keep in mind that the volume and pan settings that you
+      find on the Mixer are global settings.  The per-note velocity and pan settings in the Pattern editor
+      are settings that are relative to the settings in the Mixer window !</para>
 
-        <para>If things sound bad and distorted, start by turning down the gain
-        setting on the layer... especially if it's larger than 1.0.  Then turn
-        down the instrument gain.  Then any gain on a LADSPA effect.  Then the
-        fader on the mixer.  Then the master output fader.</para>
 
-        <para><emphasis role="bold">Test samples at full velocity.</emphasis>
-        Your sample will be played louder if the velocity is higher.  So, if you
-        set everything to sound nice and full with velocity at 0.7, what will
-        happen when you get a full velocity of 1.0?  (<emphasis>Hint:
-        clipping.</emphasis>)</para>
+    </sect1>
+    
+    <sect1 id="sect.fx_rack_LADSPA">
+      <title>FX Rack and LADSPA Plugins</title>
+       <para>The FX rack has 4 bays where you can load a LADSPA effect plugin, but before
+        you can load any plugins these must be installed (surprised ?  ;-)</para>
+        <para>There are dozens of plugins available for download from various sources :
 
-        <para><emphasis role="bold">Try to use samples that are -6 dB
-        max.</emphasis> Visually, this means samples that peak at only
-        1/2 of full scale.  Otherwise, turn your layer gain to about
-        .5.</para>
+      <itemizedlist>
+        <listitem>
+          <para><emphasis role="bold"><abbrev>SWH</abbrev>-Plugins</emphasis>: available at <ulink
+          url="http://plugin.org.uk">http://plugin.org.uk</ulink>. </para>
+          <note>
+            <para>If you want to compile these plugins
+          you need the <application>FFTW</application> tarball from <ulink
+          url="http://www.fftw.org">http://www.fftw.org</ulink>)
+            </para>
+          </note>
+        </listitem>
 
-        <para><emphasis role="bold">Remove all DC offsets from the
-        sample.</emphasis> In a sample editor, there is usually a line down the
-        center of your sample's waveform.  This is the zero-line.  The beginning
-        of your sample should be on this line.  The end of your sample should
-        also be on this line.  However, if your signal is a little above or a
-        little below this line, you will hear a click at the beginning and the
-        end of your sample whenever it is played.  If your sample editor doesn't
-        provide any tools to fix a DC offset problem, you can eliminate the
-        noise by putting a slight fade-in/out at the ends of your sample.</para>
+        <listitem>
+          <para><emphasis role="bold"><abbrev>CMT</abbrev></emphasis>: available at <ulink url="http://www.ladspa.org">http://www.ladspa.org</ulink>.</para>
+        </listitem>
 
-        <para><emphasis role="bold">The ADSR will not be longer than your
-        sample.</emphasis> If you have a short sample, it doesn't matter how
-        long you set the attack and delay &mdash; the sample will stop playing
-        at the end.</para>
+        <listitem>
+          <para><emphasis role="bold"><abbrev>TAP</abbrev></emphasis>: available at <ulink url="http://tap-plugins.sf.net">http://tap-plugins.sf.net</ulink>.</para>
+        </listitem>
 
-        <para><emphasis role="bold">Things change with the sample
-        rate.</emphasis> If you have a really nice setup with all your
-        parameters painstakingly tweaked... things <emphasis>will</emphasis>
-        change if you change the sample rate of your audio card.  Many of
-        Hydrogen's internal settings and parameters are based on how many
-        samples go by, not on how many seconds go by.  The sorts of things
-        that change are: anything time-base (like attack and release) and
-        anything frequency based (like the cutoff frequency).</para>
+        <listitem>
+          <para><emphasis role="bold">Calf plugins</emphasis>: available at <ulink url="http://calf.sourceforge.net/">http://calf.sourceforge.net/</ulink>.</para>
+        </listitem>
 
-      </sect1>
-    </chapter>
+        <listitem>
+          <para><emphasis role="bold"><abbrev>LSP</abbrev> plugins</emphasis>: available at <ulink url="https://github.com/sadko4u/lsp-plugins/">https://github.com/sadko4u/lsp-plugins/</ulink>.</para>
+        </listitem>
 
+        <listitem>
+          <para> ....</para>
+        </listitem>
+
+      </itemizedlist>
+      </para>
+      
+      <warning>
+        <title>Plugins Kill</title>
+        <para>A badly designed <abbrev>LADSPA</abbrev> plugin is capable of
+        hanging, crashing, freezing, screeching, overflowing buffers, and even
+        phoning home.  If you start having issues with Hydrogen, disable your
+        plugins and see if things improve.  Some plugins are not designed for
+        real-time use, and some are just plain better than others.</para>
+      </warning>
+
+      <para>Once you have installed some plugins you can select one by clicking the
+      
+
+      <inlinemediaobject>
+        <imageobject>
+          <imagedata fileref="img/edit_off.png" format="PNG" />
+        </imageobject>
+      </inlinemediaobject>
+
+      button.  (if you do not see the FX rack, make sure that the 
+
+      <inlinemediaobject>
+        <imageobject>
+          <imagedata fileref="img/showFX_on.png" format="PNG" />
+        </imageobject>
+      </inlinemediaobject>
+
+      button (in the Master section) is enabled)</para>
+      <para>Now the FX selector window will pop up :
+      
+      <figure id="fig.select_effect">
+        <title>Select an Effect</title>
+        <mediaobject>
+          <imageobject>
+            <imagedata fileref="img/MixerFXSelect.png" format="PNG" />
+          </imageobject>
+        </mediaobject>
+      </figure>
+      
+      Once you have selected a plugin you will immediately have access 
+      to its parameters:
+      
+       
+        <informalfigure id="figLADSPA_FX_Properties">
+         <mediaobject>
+           <imageobject>
+             <imagedata fileref="img/LADSPA_FX_Properties.png" format="PNG" />
+           </imageobject>
+         </mediaobject>
+         </informalfigure>
+
+
+      You can select another plugin by clicking the 'Select FX' button. If you quickly want to 
+      enable/disable the effect click the 'Deactivate' button (or the Bypass (
+
+      <inlinemediaobject>
+        <imageobject>
+          <imagedata fileref="img/bypass_over.png" format="PNG" />
+        </imageobject>
+        </inlinemediaobject>)
+
+      button in the FX rack).  This can be handy for a quick A/B comparison.</para>
+      
+      <para>After you have selected the FX and tweaked it's parameters you can use the 
+      FX return knob to increase/decrease how much of this FX will be returned to the master output.</para>
+
+    </sect1>
+     
+    <sect1 id="sect.master">
+      <title>Master Section</title>
+       <para>
+       
+      The Master section contains the Master volume fader with VU meters and three global Humanize 
+      settings for Velocity, Timing and Swing (in order to add a 'human feel' to the song):
+      
+     <itemizedlist>
+        <listitem>
+          <para><emphasis role="bold">Velocity</emphasis>: adds a certain randomness to the note velocity. 
+           The higher you turn this knob, the more the velocity will be randomized.
+          </para>
+        </listitem>
+
+        <listitem>
+          <para><emphasis role="bold">Timing</emphasis>: adds a certain randomness to the note timing (lead/lag).  
+            The higher you turn this knob, the more the timing will be randomized.
+          </para>
+          <note><para>Notes are displaced in time (using Gaussian perturbation)
+            but the pattern durations or bpm do not change.</para>
+          </note>
+          
+        </listitem>
+        
+       <listitem>
+          <para><emphasis role="bold">Swing</emphasis>: this knob will add a certain amount of swing to the song.</para>
+          <note> <para> Swing (a slight time delay) is applied to upbeat 16th-notes,
+          and not to 8th-notes as it happens in traditional Jazz.</para> </note>
+        </listitem>        
+        
+     </itemizedlist>
+       </para>
+       <note>
+         <para>
+      Note that Hydrogen can also be switched to 'per instrument output' mode (see <xref linkend="chpt.preferences.audio_tab"/>),
+      and in this mode all channel strip outputs will be available in <abbrev>JACK</abbrev> (not just the Master output).  
+      This allows you to route the individual instruments directly into any other <abbrev>JACK</abbrev> enabled application (eg Ardour) and gives you
+      a lot more flexibility.
+         </para>
+       </note>
+      
+      <para>On the bottom-right of the Master section the 'FX' button 
+        <inlinemediaobject>
+          <imageobject>
+            <imagedata fileref="img/showFX_on.png" format="PNG" />
+          </imageobject>
+        </inlinemediaobject>      
+        will show/hide the FX rack, and the 'Peak' button 
+       
+      <inlinemediaobject>
+        <imageobject>
+          <imagedata fileref="img/showPeaks_on.png" format="PNG" />
+        </imageobject>
+      </inlinemediaobject>       
+       will enable/disable the VU meters.
+       
+       <note>
+       <para>The VU meter fall off speed can be configured in the preferences window (see <xref linkend="chpt.preferences.appearance_tab"/>)</para>
+       </note>
+       
+      </para>
+  
+      <para>  In the upper part of Master section there is a small "cog" icon button:</para>
+
+        <informalfigure id="mixerSettingsButton">
+         <mediaobject>
+           <imageobject>
+             <imagedata fileref="img/mixerSettingsButton.png" format="PNG" />
+           </imageobject>
+         </mediaobject>
+         </informalfigure>
+         <para>
+
+         Click it to open the Mixer Settings window:
+
+         <informalfigure id="mixerSettingsDialog">
+         <mediaobject>
+           <imageobject>
+             <imagedata fileref="img/mixerSettingsDialog.png" format="PNG" />
+           </imageobject>
+         </mediaobject>
+         </informalfigure>
+          Here you can select the <emphasis role="bold">Pan Law</emphasis> used by Hydrogen Mixer.
+          </para>
+         <para>
+             The Pan Law is the relationship between the pan knob and the separate gains of Left and Right outputs.
+             The aim is to control the horizontal angle the sound seems to arrive from.
+         </para>
+         <para>
+            Hydrogen features one the most customizable and accurate Pan Law set. </para>
+            
+          <para>
+             You will find four categories: <emphasis>linear</emphasis>, <emphasis>polar</emphasis>,
+             <emphasis>ratio</emphasis>, <emphasis>quadratic</emphasis>.
+             Every category gives a different "scale" or "sensibility" to the pan knob:
+              the same knob position will make the sound appear more lateral or central depending on the category,
+              from the most lateral (<emphasis>linear</emphasis>) to the most central (<emphasis>quadratic</emphasis>).
+         </para>
+         
+         <para>
+           Then for each category you will find four options, that define a <emphasis>constraint</emphasis> between the
+            gains of the two channels:     
+           <itemizedlist>
+                <listitem>
+                  <para><emphasis role="bold">Balance Law (0dB)</emphasis>: 
+                  when you turn the pan knob from center to right, the right gain stays constant at maximum level
+                   while the left gain decreases from the maximum level to 0 (and symmetrically turning from center to left). </para>
+                    <para>It is ideal for balancing a DUAL-channel track. It has ZERO center compensation: the sound 
+                    will be <emphasis>louder</emphasis> when the pan knob is at <emphasis>center</emphasis> -
+                    unless channels are out of phase - so you may have to readjust the volume manually with the
+                     mixer fader.
+                  </para>
+                </listitem>
+                
+                <listitem>
+                  <para> <emphasis role="bold">Constant Power (-3dB)</emphasis>: the total <emphasis>power</emphasis>
+                   (which is proportional to the <emphasis>square</emphasis> of the gain) is constant for any position
+                    of the pan knob. </para>
+                    <para>Compared to the Balance Law, each channel gain is divided by the square root of 2
+                    when the pan knob is at center (-3.0103 dB center compensation).
+                    In a common room, this constraint <emphasis>may</emphasis> give the general perception of uniform
+                     volume for any pan knob position (panning a MONO track).
+                  </para>
+                </listitem>
+                
+                <listitem>
+                  <para> <emphasis role="bold">Constant Sum (-6dB)</emphasis>: the sum of left and right gains is
+                   constant for any position of the pan knob. </para>
+                     <para>This constraint preserves the mix volumes in mono export.
+                     Compared to the Balance Law, each channel gain is halved (-6.0206 dB) when the pan knob
+                      is at center.
+                     If you are in an ideal anechoic room (where there are no acoustic reflections)
+                     and you seat perfectly at the same distance from the speakers,
+                     with this constraint the volume will be really constant for any pan position, because of the linear
+                     <emphasis>super-position</emphasis> of sound waves (panning a MONO track).
+                  </para>
+                </listitem>
+
+               <listitem>
+                  <para><emphasis role="bold">Constant k-Norm (Custom dB center compensation)</emphasis>:
+                   you can experiment adjusting the center compensation to your
+                  taste! </para>
+                  <note>
+                    <para>Note that some hi-end studio mixers - to be used in well tuned rooms -
+                    have center compensation between -3dB and -6dB.
+                    </para>
+                  </note>
+                </listitem>
+             </itemizedlist>
+             </para>
+
+          <para>The four constraints should not change the perception of the <emphasis>stereo angle</emphasis>,
+          but the <emphasis>volume</emphasis> only (depending on the pan knob).
+         </para>
+         <para>
+          The Pan Law is something you should choose <emphasis>before</emphasis> starting the mix and keep untouched.
+           Hydrogen sets the <emphasis>ratio Balance Law</emphasis> by default because it was the only available law
+            until version 1.0 (so old songs and drumkits will sound the same).
+          The setting is saved in the songfile but not in preferences, 
+          so it is NOT remembered when you create a new song.
+         </para>
+       <note>
+       <para>Unlike in advanced mixers, Hydrogen panning makes no distinction if a track is mono or dual-channel (stereo).
+       You cannot pan each channel of stereo tracks separately, nor use a balance law for them and another
+       pan law for mono tracks.
+        If the drumkit you are using is made of true stereo samples, you don't want a negative center compensation
+         probably, so you should select a Balance Law.</para>
+       </note>
+
+
+    </sect1>
+    
+  </chapter>
+
+    
+   <chapter id="chpt.director" xreflabel="Director">
+     <title>Director</title>
+     <para>
+       Now all we need is a way to see the tags we have entered.  This can be done
+       using the Director window.  Open the Director by pressing Alt-D, or Tools- Director :
+
+       <informalfigure id="fig.director">
+         <mediaobject>
+           <imageobject>
+             <imagedata fileref="img/screenshot-director.png" format="PNG" />
+           </imageobject>
+         </mediaobject>
+       </informalfigure>
+       
+       The Director is your best friend when you need a quick overview of what Hydrogen
+       is currently doing.  This comes in very handy when you are recording a song, or
+     if you are using Hydrogen live on stage.</para>
+     
+     <para>
+       The Director shows you the song name, a visual metronome and of course the
+       song Tags.  Just below the metronome you can see the latest tag, and below that
+       the next upcoming tag.  This way you have a nice overview of what is going on,
+       and what is about to happen in the song.
+     </para>
+   </chapter>
+
+   <chapter id="chpt.playlist_editor">
+     <title>Playlist Editor</title>
+     <para>
+	   TODO
+     </para>
+   </chapter>
     <chapter id="chpt.midi">
-      <title>MIDI</title>
+      <title>MIDI API</title>
       
       <para>In this section you can find more info about defining <abbrev>MIDI</abbrev> actions 
        and how they can be useful for you.  Before you can work with midi actions
@@ -3543,14 +3381,14 @@
       <listitem><para>
 	      <emphasis role="bold">BEATCOUNTER</emphasis> : calculates the average
           time passing between successive encounters of this commands and uses
-          it to set the current tempo. (see <xref linkend="sect.tap_tempo"/>)
+          it to set the current tempo. (see <xref linkend="sect.main_toolbar.tap_tempo_beat_counter"/>)
 	    </para></listitem>
 	    
       <listitem><para>
 	      <emphasis role="bold">TAP_TEMPO</emphasis> : another command
           calculating the average time passing between successive encounters of
           this commands and uses it to set the current tempo (see <xref
-          linkend="sect.tap_tempo"/>)
+          linkend="sect.main_toolbar.tap_tempo_beat_counter"/>)
 	    </para></listitem>
 	    
       <listitem><para>
@@ -3566,7 +3404,7 @@
    </chapter>
    
    <chapter id="chpt.osc" xreflabel="OSC">
-	 <title>OSC</title>
+	 <title>OSC API</title>
 	 <para>Open Sound Control (<abbrev>OSC</abbrev>) is a protocol for communication among
      programs, computers, and hardware, like synthesizers or multimedia
      devices, via networking protocols such as UDP or TCP. It can be thought
@@ -3594,7 +3432,7 @@
      </para>
      
      <sect1 id="chpt.osc.messages">
-       <title>OSC messages</title>
+       <title>OSC Messages</title>
        <para>The syntax for sending the commands is</para>
 
        <screen>
@@ -3659,7 +3497,7 @@
        </itemizedlist>
 
        <table frame='all' id='chpt.osc.messages.playback.table'>
-         <title>OSC playback messages</title>
+         <title>OSC Playback Messages</title>
          <tgroup cols='3' align='left' colsep='1' rowsep='1'>
            <colspec colname='cURL'/>
            <colspec colname='cType'/>
@@ -3797,7 +3635,7 @@
                <entry></entry>
                <entry>Calculates the average time passing between successive
                encounters of this commands and uses it to set the current
-               tempo (see <xref linkend="sect.tap_tempo"/>).</entry>
+               tempo (see <xref linkend="sect.main_toolbar.tap_tempo_beat_counter"/>).</entry>
              </row>
              <row>
                <entry>/Hydrogen/<emphasis role="bold">TAP_TEMPO</emphasis>/</entry>
@@ -3805,7 +3643,7 @@
                <entry></entry>
                <entry>Another command calculating the average time passing
                between successive encounters of this commands and uses it to
-               set the current tempo (see <xref linkend="sect.tap_tempo"/>).</entry>
+               set the current tempo (see <xref linkend="sect.main_toolbar.tap_tempo_beat_counter"/>).</entry>
              </row>
              <row>
                <entry>/Hydrogen/<emphasis role="bold">TIMELINE_ACTIVATION</emphasis>/</entry>
@@ -4042,6 +3880,12 @@
        </table>
 	 </sect1>
    </chapter>
+   <chapter id="chpt.nsm">
+     <title>NSM Support</title>
+     <para>
+	   TODO
+     </para>
+   </chapter>
  </part>
  <!--
      ##################
@@ -4051,9 +3895,9 @@
  <part id="part.demos">
    <title>Examples</title>
    <chapter id="chpt.create_song">
-     <title>A new song</title>
+     <title>A New Song</title>
      <sect1 id="sect.song_vs_pattern">
-       <title>"Song" mode and "Pattern" mode</title>
+       <title>"Song" Mode and "Pattern" Mode</title>
 
        <para>This section is a quick-and-dirty walkthrough to Hydrogen. Refer to the
        tutorial for a more detailed overview.</para>
@@ -4068,7 +3912,7 @@
      </sect1>
 
      <sect1 id="sect.create_pattern">
-       <title>A new pattern</title>
+       <title>A New Pattern</title>
        <para>We'll start from the empty song with an empty pattern created when
        Hydrogen starts up: "pattern" mode should be selected by default. Now
        let's click on the <quote>Play</quote>button, and while the pattern is playing
@@ -4095,14 +3939,14 @@
      </sect1>
 
      <sect1 id="sect.create_sequence">
-       <title>A new sequence</title>
+       <title>A New Sequence</title>
 
        <para>Once patterns are created (<xref linkend="fig.insert_patterns"/>), we
        can copy/paste/delete them using the Select Mode (see <xref linkend="chpt.song_editor.main_controls"/>).
        </para>
 
        <figure id="fig.insert_patterns">
-         <title>Inserting Patterns in the Song sequence</title>
+         <title>Inserting Patterns in the Song Sequence</title>
          <mediaobject>
            <imageobject>
              <imagedata fileref="img/SongEditor.png" format="PNG" />
@@ -4112,7 +3956,7 @@
 
      </sect1>
      <sect1 id="sect.create_song.adjust_mixer">
-       <title>Adjust from the mixer</title>
+       <title>Adjust from the Mixer</title>
 
        <para>Of course we can always use the mixer window, either when creating
        or playing patterns.</para>
@@ -4182,14 +4026,185 @@
          </mediaobject>
        </figure>
      </sect1>
-  </chapter>
+   </chapter>
+   <chapter id="chpt.examples.drumkit">
+	 <title>Create a New Drumkit</title>
+     <para>TODO: make consistent</para>
+     
+      <sect1 id="chpt.instrument_editing.new_kit">
+       <title>Creating a New Drumkit</title>
+       <para>In the next paragraphs we will show you how to create a complete drumkit.  
+       Keeping in mind the 'Soundlibrary hierarchy' (see <xref linkend="fig.SoundlibraryHierarchy"/>)
+       we will use a top-down approach, so we will start at the Drumkit level and work our way 
+       down to the samples.</para> 
+        
+       <para>Creating a new drumkit with Hydrogen is done with the Instrument
+       Editor.  You can load samples, set envelope
+       parameters, set the gain, and other advanced features like mute
+       groups, a low-pass resonance filter, and pitch randomization.</para>
+
+       <para>TIP : Instead of creating your own drumkit, you can also use or download
+       existing drumkits using the <xref linkend="chpt.sound_library"/>.</para>
+
+        <para>Lets make a  brand new drum kit :</para>
+        <procedure>
+          <step><para>select
+          <menuchoice>
+            <guimenu>Instruments</guimenu>
+            <guimenuitem>"Clear All"</guimenuitem>
+          </menuchoice>
+
+          .  This will give you a bank of 32 blank instruments.  To delete
+          instruments, right-click on on each instrument and select
+          "<guimenuitem>Delete Instrument</guimenuitem>".  To add more instruments,
+          select
+
+          <menuchoice>
+            <guimenu>Instruments</guimenu>
+            <guimenuitem>"Add instrument"</guimenuitem>
+          </menuchoice>
+          .</para>
+          </step>
+
+
+          <step>
+          <para>Select an instrument to start editing it.  This is done by
+          left-clicking on the name of the instrument in the instrument list (at
+          the left).  You will notice that the name of the instrument in the
+          Instrument Editor matches the one that you clicked.</para>
+          </step>
+         
+          <step>
+          <para>Once you have your drum kit working the way you want, select
+
+          <menuchoice>
+            <guimenuitem>Instruments</guimenuitem>
+            <guimenuitem>"Save library"</guimenuitem>
+          </menuchoice>
+
+          .  You will be prompted for the name of the kit to save.  If you wish to
+          <emphasis>overwrite</emphasis> an existing kit, you will need to type in
+          the same name as the kit that you want to replace.</para>
+         </step>
+
+         <step>
+          <para>Drumkits are automatically stored in the <filename
+          class="directory">data</filename> directory (i.e. <filename
+          class="directory">$HOME/.hydrogen/data/drumkits</filename>).</para>
+         </step>
+
+         <step>
+          <para>To export a drumkit (for sharing with others), it must first be
+          loaded into your Sound Library.  Then, select
+
+          <menuchoice>
+            <guimenuitem>Instruments</guimenuitem>
+            <guimenuitem>"Export library"</guimenuitem>
+          </menuchoice>
+
+          from the menu.  Select the drum kit that you wish to export, and give it
+          a file name to save it to.</para>
+          </step>
+        </procedure>
+
+      </sect1>
+
+      <sect1 id="chpt.instrument_editing.tips">
+        <title>Tips on Editing Instruments</title>
+
+        <para>With all of the different parameters available to tweak, it can be
+        difficult to set up something that sounds nice when you're done.  Here are 
+        a few tips on setting up an instrument:</para>
+
+        <para><emphasis role="bold">Turn down the gain.</emphasis> Every gain
+        knob (i.e. an amplifier), this is a <emphasis>gain stage</emphasis>.  
+        With every gain stage you have, it's
+        easy to overdrive your signal &mdash; which means the signal gets
+        distorted by clipping.  In addition, if you have two samples that, by
+        themselves, peg your meters &mdash; what do you think happens when you
+        combine them?  That's right, you overdrive the signal again.</para>
+
+        <para>If things sound bad and distorted, start by turning down the gain
+        setting on the layer... especially if it's larger than 1.0.  Then turn
+        down the instrument gain.  Then any gain on a LADSPA effect.  Then the
+        fader on the mixer.  Then the master output fader.</para>
+
+        <para><emphasis role="bold">Test samples at full velocity.</emphasis>
+        Your sample will be played louder if the velocity is higher.  So, if you
+        set everything to sound nice and full with velocity at 0.7, what will
+        happen when you get a full velocity of 1.0?  (<emphasis>Hint:
+        clipping.</emphasis>)</para>
+
+        <para><emphasis role="bold">Try to use samples that are -6 dB
+        max.</emphasis> Visually, this means samples that peak at only
+        1/2 of full scale.  Otherwise, turn your layer gain to about
+        .5.</para>
+
+        <para><emphasis role="bold">Remove all DC offsets from the
+        sample.</emphasis> In a sample editor, there is usually a line down the
+        center of your sample's waveform.  This is the zero-line.  The beginning
+        of your sample should be on this line.  The end of your sample should
+        also be on this line.  However, if your signal is a little above or a
+        little below this line, you will hear a click at the beginning and the
+        end of your sample whenever it is played.  If your sample editor doesn't
+        provide any tools to fix a DC offset problem, you can eliminate the
+        noise by putting a slight fade-in/out at the ends of your sample.</para>
+
+        <para><emphasis role="bold">The ADSR will not be longer than your
+        sample.</emphasis> If you have a short sample, it doesn't matter how
+        long you set the attack and delay &mdash; the sample will stop playing
+        at the end.</para>
+
+        <para><emphasis role="bold">Things change with the sample
+        rate.</emphasis> If you have a really nice setup with all your
+        parameters painstakingly tweaked... things <emphasis>will</emphasis>
+        change if you change the sample rate of your audio card.  Many of
+        Hydrogen's internal settings and parameters are based on how many
+        samples go by, not on how many seconds go by.  The sorts of things
+        that change are: anything time-base (like attack and release) and
+        anything frequency based (like the cutoff frequency).</para>
+
+      </sect1>
+   </chapter>
 </part>
 <part id="appendix">
   <title>Appendix</title>
+  
+<!-- FILETYPES -->
+    <chapter id="chpt.file_types">
+      <title>Used Filetypes</title>
+
+      <para>Before working with Hydrogen, please familiarize with these
+      filetypes:</para>
+
+      <itemizedlist>
+        <listitem>
+          <para><emphasis role="bold">*.h2pattern</emphasis>: <abbrev>XML</abbrev> file
+          describing a single pattern. Patterns are group of beats and are
+          managed in the pattern editor.</para>
+        </listitem>
+        <listitem>
+          <para><emphasis role="bold">*.h2song</emphasis>: <abbrev>XML</abbrev> file describing
+          the whole song (or sequence). Songs are group of patterns with their
+          properties and are manager using the song editor</para>
+        </listitem>
+        <listitem>
+          <para><emphasis role="bold">*.h2playlist</emphasis>: <abbrev>XML</abbrev> file
+          describing a playlist. A Playlist is a (ordered) group of songs.</para>
+        </listitem>
+        <listitem>
+          <para><emphasis role="bold">*.h2drumkit</emphasis>: a compressed and
+          archived folder containing all sound samples composing a drumkit and a
+          description <abbrev>XML</abbrev> file. Drumkits are basically group of sound
+          samples.</para>
+        </listitem>
+      </itemizedlist>
+    </chapter>
+
   <chapter id="chap.shortcuts">
-    <title>Shortcut lists</title>
+    <title>Shortcut Lists</title>
     <table frame='all' id='sect.shortcut.table'>
-      <title>Shortcut table</title>
+      <title>Shortcut Table</title>
       <tgroup cols='2' align='left' colsep='1' rowsep='1'>
         <colspec colname='cShortcut'/>
         <colspec colname='cDescription'/>
@@ -4230,7 +4245,7 @@
           </row>
           <row>
             <entry><keycap>CTRL</keycap> + <keycap>E</keycap></entry>
-            <entry>Export Song (see <xref linkend="chpt.song_editor.export_song"/>)</entry>
+            <entry>Export Song (see <xref linkend="sect.main_form.export_song"/>)</entry>
           </row>
           <row>
             <entry><keycap>CTRL</keycap> + <keycap>L</keycap></entry>
@@ -4250,7 +4265,7 @@
           </row>
           <row>
             <entry><keycap>ALT</keycap> + <keycap>D</keycap></entry>
-            <entry>Show Director (see <xref linkend="chpt.song_editor.director"/>)</entry>
+            <entry>Show Director (see <xref linkend="chpt.director"/>)</entry>
           </row>
           <row>
             <entry><keycap>ALT</keycap> + <keycap>M</keycap></entry>
@@ -4298,11 +4313,11 @@
           </row>
           <row>
             <entry><keycap>,</keycap></entry>
-            <entry>Use Beatcounter (see <xref linkend="sect.tap_tempo"/>)</entry>
+            <entry>Use Beatcounter (see <xref linkend="sect.main_toolbar.tap_tempo_beat_counter"/>)</entry>
           </row>
           <row>
             <entry><keycap>\</keycap></entry>
-            <entry>Use Tap Tempo (see <xref linkend="sect.tap_tempo"/>)</entry>
+            <entry>Use Tap Tempo (see <xref linkend="sect.main_toolbar.tap_tempo_beat_counter"/>)</entry>
           </row>
           <row>
             <entry><keycap>+</keycap></entry>

--- a/manual.docbook
+++ b/manual.docbook
@@ -29,7 +29,7 @@
     <abstract>
       <para>Hydrogen is a software synthesizer which can be used alone,
       emulating a drum machine based on patterns, or via an external <abbrev>MIDI</abbrev>
-      keyboard/sequencer software. Hydrogen compiles on Linux, Mac OS X and Windows.</para>
+      keyboard/sequencer software. Hydrogen runs on Linux, Mac OS X and Windows.</para>
     </abstract>
   </bookinfo>
 
@@ -48,23 +48,27 @@
       <para>
         You can download Hydrogen from 
         <ulink url="http://www.hydrogen-music.org/hcms/node/21">http://www.hydrogen-music.org</ulink>.  
-        On the 'Downloads' page you can find several binaries (installers) for Linux, Mac and Windows.
+        On the <emphasis>Downloads</emphasis> page you can find several binaries (installers) for MacOS and Windows.
       </para>
-      <note>
-        <para>Please note that some versions may not be available for Windows and
-        Mac
-        </para>
-      </note>
+      <para>
+	    Due to the variety of distributions we do not provide packages for Linux. If you do not find Hydrogen in the repository of your distribution, please ask the people behind it to include Hydrogen.
+      </para>
+    </chapter>
+
+<!-- COMPILATION  -->
+
+    <chapter id="chpt.compilation">
+      <title>Build</title>
 
       <para>
-        If you want to compile Hydrogen yourself (see <xref linkend="chpt.compilation"/>), you can download the latest source files directly from our
-        git repository with:
+        If you want to compile Hydrogen yourself, you can download the latest source files directly from our
+        <command>git</command> repository with
       </para>
       <screen>
         <prompt>$</prompt><command> git clone git://github.com/hydrogen-music/hydrogen.git</command>
       </screen>
       <para>
-        A certain release can be fetched with:
+        A certain release can be fetched with
       </para>
       <screen>
         <prompt>$</prompt><command> git checkout tags/1.0.0</command>
@@ -111,6 +115,11 @@
           <para><emphasis role="bold"><abbrev>LASH</abbrev></emphasis>: at <ulink url="http://lash.nongnu.org">http://lash.nongnu.org</ulink> (only if
           you wish to use <abbrev>LASH</abbrev>)</para>
         </listitem>
+        <listitem>
+	      <para>
+	        <emphasis role="bold">liblo</emphasis>: at <ulink url="http://liblo.sourceforge.net/"></ulink> for <abbrev>OSC</abbrev> and <abbrev>NSM</abbrev> support
+          </para>
+        </listitem>
       </itemizedlist>
 
       <para>Please install them with your distribution's package manager. If
@@ -125,17 +134,7 @@
 	liblash-compat-dev librubberband-dev libjack-jackd2-dev</command>
       </screen>
 
-    </chapter>
-
-<!-- COMPILATION  -->
-
-    <chapter id="chpt.compilation">
-      <title>Build</title>
-
-      <para>Depending on the branch you are compiling you will need to use <command>cmake</command>. Check the <filename>INSTALL.txt</filename> and the <filename>README.txt</filename> files for more info (located in the top level dir once you downloaded the sources).</para>
-      
-
-        <para>Compiling with <command>cmake</command> can be done easily by using the <filename>build.sh</filename> script. Go to the directory where the git repository
+        <para>Compiling with <command>cmake</command> can be done easily by using the <filename>build.sh</filename> script. Go to the directory where the <command>git</command> repository
         was cloned and run the <filename>build.sh</filename> script without any arguments to display the help :</para>
 
         <screen>
@@ -149,21 +148,36 @@
           <command>   r[m]     => all built, temp and cache files</command>
           <command>   c[lean]  => remove cache files</command>
           <command>   m[ake]   => launch the build process</command>
+          <command>   mm       => launch the build process using ccache</command>
+          <command>   mt       => launch the build process with clang tidy checks enabled</command>
           <command>   d[oc]    => build html documentation</command>
           <command>   g[raph]  => draw a dependencies graph</command>
           <command>   h[elp]   => show the build options</command>
           <command>   x|exec   => execute hydrogen</command>
           <command>   t[ests]  => execute tests</command>
           <command>   p[kg]    => build source package</command>
+          <command>   z        => build using ccache and run from tree</command>
+
         </screen>
 
-        <para>To build Hydrogen and execute the result, run the build script with the <parameter>m</parameter> option :
+        <para>To build Hydrogen and execute the result, run the build script with the <parameter>m</parameter> option
         </para>
       
         <screen>
            <prompt>$</prompt> <command>./build.sh m x</command>
         </screen>              
-      
+
+        <para>and to install it permanently on your computer, change into the <filename>build</filename> folder and use the <command>make</command> command.
+        </para>
+
+        <screen>
+          <prompt>$</prompt> <command>cd build</command>
+          <prompt>$</prompt> <command>sudo make install</command>
+        </screen>
+        
+        <note>
+          <para>For further details about the installation process please have a look the <filename>INSTALL.txt</filename> file (located in the top level dir once you downloaded the sources).</para>
+        </note>
     </chapter>
 
 <!--   KEYBOARD AND MOUSE -->
@@ -173,9 +187,23 @@
         The Hydrogen user interface is designed so that it can be
         used entirely with the mouse, with the exception of text entry.
       </para>
+
+      <itemizedlist>
+	    <listitem>
+	      <para>
+	        <keycap>Ctrl</keycap> + <keycap>left click</keycap>: restore default value of knob or fader
+          </para>
+        </listitem>
+        <listitem>
+	      <para>
+	        <keycap>Shift</keycap> + <keycap>left click</keycap>: bind <abbrev>MIDI</abbrev> event to <abbrev>MIDI</abbrev>-learnable widget (see <xref linkend="chpt.midi.learnable"/>
+          </para>
+        </listitem>
+      </itemizedlist>
+      
       <para>
         The keyboard can also be used for navigating and editing in
-        the pattern and song editors, using a combination of 
+        the <link linkend="chpt.pattern_editor">Pattern</link> and <link linkend="chpt.song_editor">Song Editors</link>, using a combination of 
         <itemizedlist>
           <listitem>
             <para>
@@ -202,7 +230,7 @@
           <listitem>
             <para>
               <emphasis role="bold"><keycap>Tab</keycap> and <keycap>Shift</keycap> + <keycap>Tab</keycap></emphasis> : move
-              between different areas of the main interface.
+              between the Pattern, Songn and Note Property Editor.
             </para>
           </listitem>
           <listitem>
@@ -224,6 +252,8 @@
         Note that the keyboard input cursor is hidden
         from view until one of the above keys is pressed. This keeps
         the display clear and uncluttered when using the mouse.
+
+        TODO: link and mention the corresponding option in the Preferences
         </para>
       </note>
       <para>
@@ -3273,8 +3303,13 @@
        
         
        </sect1>
-       
 
+       <sect1 id="chpt.midi.learnable">
+         <title>MIDI-learnable Widgets</title>
+         <para>
+	       TODO
+         </para>
+       </sect1>
       <sect1 id="chpt.midi.actions">
         <title>MIDI Actions</title>
 

--- a/manual.docbook
+++ b/manual.docbook
@@ -238,13 +238,13 @@
           </listitem>
         </itemizedlist>
       </para>
-      <note>
-        <para>
-        Note that the keyboard input cursor is hidden
-        from view until one of the above keys is pressed. This keeps
-        the display clear and uncluttered when using the mouse.
 
-        TODO: link and mention the corresponding option in the Preferences
+      <note>
+	    <para>
+          Note that the keyboard input cursor is hidden from view until one of
+          the above keys is pressed. This keeps the display clear and
+          uncluttered when using the mouse. You can alter this default behavior in the <link linkend="chpt.preferences.general_tab">General tab</link> of the Preferences.
+	      
         </para>
       </note>
       <para>
@@ -1213,8 +1213,6 @@
         </sect1>
     </chapter>
 
-
-<!-- SONG EDITOR -->
     <chapter id="chpt.song_editor">
       <title>Song Editor</title>
 
@@ -1223,18 +1221,37 @@
         <title>The Song Editor</title>
         <mediaobject>
           <imageobject>
-            <imagedata fileref="img/SongEditor.png" format="PNG" />
+            <imagedata fileref="img/EnablePlaybackTrack.png" format="PNG" />
           </imageobject>
         </mediaobject>
       </figure>
       </para>
 
-      <para>The "Song Editor" (<xref linkend="fig.song_editor"/>) gives an
-      overview of the whole timeline of the song (e.g. intro, verse, bridge,
-      chorus and so on); each blue colored square on this panel represents a complete
-      bar as shown in the underlying "Pattern Editor" panel. The song editor gives
+      <para>
+	    TODO: how about having multiple patterns of different lengths in one column of the screenshot?
+      </para>
+      <para>The Song Editor gives an
+      overview of the whole song (e.g. intro, verse, bridge,
+      chorus and so on). Each blue colored square on this panel represents a pattern. In case of multiple patterns of different lenghts in one column only the largest one(s) will be represented by a square. The shorter patterns are indicated by rectangles which width indicate their length relative to the longest one.</para>
+
+      <tip>
+	    <para>
+	      Instead of having the same color for all patterns you can set different colors schemes in the <link linkend="chpt.preferences.appearance_tab">Appearance tab</link> in the Preferences.
+        </para>
+      </tip>
+      
+      <para>
+        The song editor gives
       you complete freedom to add/remove patterns to the song and to move or 
       copy any part of your song.
+      </para>
+
+      <para>
+	    TODO: describe the different ways of editing (groups of) patterns using mouse and keyboard. (New UX)
+      </para>
+
+      <para>
+	    TODO: description about how to use the song ruler for navigation.
       </para>
       
      <sect1 id="chpt.song_editor.main_controls">
@@ -1247,12 +1264,12 @@
         </inlinemediaobject>
       </para>
 
-      <itemizedlist mark="opencircle">
+      <itemizedlist>
 
         <listitem>
           <para><inlinemediaobject><imageobject>
             <imagedata fileref="img/btn_clear_off.png" format="PNG"/>
-            </imageobject></inlinemediaobject> Completely delete all patterns
+            </imageobject></inlinemediaobject> : deletes all patterns
             (asks for confirmation!).
           </para>
         </listitem>
@@ -1260,67 +1277,86 @@
         <listitem>
           <para><inlinemediaobject><imageobject>
             <imagedata fileref="img/btn_new_on.png" format="PNG" />
-            </imageobject></inlinemediaobject> Create a new pattern (and asks
-            for a name).
+            </imageobject></inlinemediaobject> : creates a new pattern (and asks for a name).
           </para>
         </listitem>
 
         <listitem>
           <para><inlinemediaobject><imageobject>
             <imagedata fileref="img/btn_updown.png" format="PNG" />
-            </imageobject></inlinemediaobject> Move currently selected pattern
-            up or down.</para>
-            <note>
-              <para>
-                Note that you can also just drag-and-drop a pattern up/down in
-                the pattern list.
-              </para>
-            </note>
+            </imageobject></inlinemediaobject> : moves currently selected pattern
+            up or down.
+          </para>
+          
+          <tip>
+            <para>
+              You can also drag-and-drop a pattern up/down in
+              the pattern list.
+            </para>
+          </tip>
         </listitem>
 
         <listitem>
           <para><inlinemediaobject><imageobject>
             <imagedata fileref="img/btn_draw.png" format="PNG"/>
-            </imageobject></inlinemediaobject> Enable Draw Mode.  This mode allows
-            you to create a song by drawing blocks on the song canvas.</para>
-            <para>Clicking a square on the song canvas will add a pattern (the square 
-            will turn blue), clicking it again will remove that pattern from the song.
+            </imageobject></inlinemediaobject> : enables Draw Mode.  This mode allows
+            you to insert patterns by drawing - holding the left button while moving the mouse - blocks on the song canvas.
+          </para>
+          <para>Clicking a square on the song canvas will add a pattern (the square 
+            will turn blue) and clicking it again will remove it.
           </para>
           <para>
-            Using the arrow keys on the keyboard, and the Return key,
-            will also add and remove patterns from the song. The
-            keyboard input cursor is usually hidden unless you press
-            one of the arrow keys.
+            Using the arrow keys on the keyboard, and the <keycap>Return</keycap>,
+            will also add and remove patterns from the song.
           </para>
+
+          <note>
+	        <para>
+              The keyboard input cursor is usually hidden unless you press one
+              of the keys listed in <xref linkend="chpt.keyboard_and_mouse" />.
+              You can alter this default behavior in the <link
+              linkend="chpt.preferences.general_tab">General tab</link> of the
+              Preferences.
+            </para>
+          </note>
+          
         </listitem>
 
         <listitem>
           <para><inlinemediaobject><imageobject>
             <imagedata fileref="img/btn_select.png" format="PNG"/>
-            </imageobject></inlinemediaobject> Enable Select Mode.  This mode allows 
-            you to select a part of the song and delete/move/copy it.</para>
+            </imageobject></inlinemediaobject> : enables Select Mode.  This mode allows 
+            you to select multiple patterns in the Song Editor and delete/move/copy them.</para>
 		<para>Once you have selected a part of your song you can <emphasis role="bold">delete</emphasis> 
-			it by pressing the Delete button.  You can <emphasis
+			it by pressing the <keycap>Delete</keycap>.  You can <emphasis
              role="bold">move</emphasis> it by simply dragging your selection
-            to another location, and you can also <emphasis role="bold">copy</emphasis>
-             your selection by Ctrl-dragging it to a new location.
+            to another location with your mouse or by cutting (<keycap>Ctrl</keycap> + <keycap>x</keycap>) and pasting (<keycap>Ctrl</keycap> + <keycap>v</keycap>) using your kyeboard. You can also <emphasis role="bold">copy</emphasis>
+             your selection by either holding <keycap>Ctrl</keycap> while dragging it to a new location or by copying (<keycap>Ctrl</keycap> + <keycap>c</keycap>) and pasting (<keycap>Ctrl</keycap> + <keycap>v</keycap>) using your kyeboard.
           </para>
           <para>
-            Selections can be modified by Ctrl-clicking to select
+            Selections can be modified by holding <keycap>Ctrl</keycap> while clicking to select
             additional blocks, or to remove selected blocks from the
             selection.
           </para>
           <para>
             The arrow keys on the keyboard can also be used, along
-            with the Return key, to <emphasis
+            with <keycap>Return</keycap>, to <emphasis
             role="bold">select</emphasis>, <emphasis
             role="bold">move</emphasis> and <emphasis
-            role="bold">copy</emphasis> (Ctrl+Return) parts of the
+            role="bold">copy</emphasis> (<keycap>Ctrl</keycap> + <keycap>Return</keycap>) parts of the
             song.
+
+            TODO: is this still valid? It doesn't work for me.
           </para>
           <para>
-            Pressing Escape will cancel an editing operation that's in
+            Pressing <keycap>Esc</keycap> will cancel an editing operation that's in
             progress, or clear any selection.
+
+            TODO: if I'm not mistaking there are now several additional ways to cancel a selection too.
+          </para>
+
+          <para>
+	        TODO: how about we move the description of the Draw and Select Mode into the previous section or create a dedicated section just for them? It describes the behavior of the overall Song Editor instead of this button. In here there would just be "enables Select mode" including a link to the dedicated section.
           </para>
         </listitem>
 
@@ -1333,14 +1369,22 @@
             </imageobject></inlinemediaobject>
             or to "Stacked pattern mode".</para>
             <para>For more info on this see the SELECT_NEXT_PATTERN midi action in <xref linkend="chpt.midi"/>.
-          </para>
+            </para>
+
+            <para>
+	          TODO: move description in here.
+            </para>
         </listitem>
       </itemizedlist>
 
       </sect1>
 
      <sect1 id="chpt.song_editor.pattern_options">
-     <title>Patterns Options</title>
+       <title>Patterns Options</title>
+
+       <para>
+	     TODO: update option list and description. update or drop image
+       </para>
 
       <para>Right-clicking the name of a pattern will show you a menu 
       where you can change a number of things :</para>
@@ -1394,6 +1438,9 @@
         <listitem>
           <para><emphasis role="bold">Properties</emphasis>: will open a window where you can change 
           the name of the pattern and also assign it to a certain category.
+
+          TODO: elaborate the concept of a "category".
+          
            <informalfigure id="fig.pattern_properties">
             <mediaobject>
               <imageobject>
@@ -1449,30 +1496,33 @@
       
      <sect1 id="chpt.song_editor.timeline">
        <title>Timeline</title>
-       <para>
-	     TODO: add image of Timeline
-       </para>
-       <para>This section describes how you can define tempo changes and 
-       how you can add tags to your song.</para>
-       <sect2 id="chpt.song_editor.timeline.tempo_marker">
-         <title>Tempo Markers</title>
+
+       <informalfigure id="fig.tempo_bar">
+         <mediaobject>
+           <imageobject>
+             <imagedata fileref="img/tempo_bar.png" format="PNG" />
+           </imageobject>
+         </mediaobject>
+       </informalfigure>
+        
        <para>The majority of songs consist of several parts (intro, verse, chorus ...) and
        often these parts will have a different tempo.  Hydrogen provides an easy way
        to let you change the tempo of a song at any given moment in the song.  This is 
-       done by adding Tempo change Markers to your song.</para>
-       <para>To add a Tempo change marker to your song you first need to enable the 'BPM' option
-       (the BPM button is located just above the Song editors main controls).  Once this is done
-       the horizontal bar next to the BPM button changes to a ruler with marks at every bar.
-       Now simply left-click this ruler at the bar you want the tempo to change and a
+       done by adding <emphasis>Tempo Markers</emphasis> to your song.</para>
+       <para>To add a Tempo Marker you first need to show the Timeline by clicking the 'T' button (TODO: add image) at the bottom of the Song Editor or via the <link linkend="sect.main_menu.view">View</link> element of the Main Menu and enable it using the 'BPM' (TODO: add image here) button.  Once this is done
+       the horizontal bar next to the button changes to a ruler with marks at every bar.
+       Now simply <keycap>left-click</keycap> this ruler at the bar you want the tempo to change and a
        window will pop up where you can enter the new tempo.
        </para>
+       
        <note>
          <para>
          Please note that the ruler will not be available while using the <abbrev>JACK</abbrev>
-         transport in 'slave' mode.
+         transport in <emphasis>slave</emphasis> mode (see <xref linkend="sect.main_toolbar.jack_control" /> for details.
          </para>
        </note>
-       <para>     
+       <para>
+         
         <informalfigure id="fig.add_tempo_change">
          <mediaobject>
            <imageobject>
@@ -1482,105 +1532,109 @@
          </informalfigure>
             
        Once you have entered the new tempo and clicked OK, the tempo change will 
-       show up on the tempo ruler.  If you click the Tempo marker again you can edit 
-       the tempo, change the bar or delete the tempo marker.
+       show up on the Timeline. If you click the Tempo Marker again you can edit 
+       the tempo, change the bar or delete it.
+       </para>
 
-        <informalfigure id="fig.tempo_bar">
+     </sect1>
+     
+     <sect1 id="chpt.song_editor.tag">
+       <title>Tags</title>       
+
+       <informalfigure id="fig.tag_bar">
          <mediaobject>
            <imageobject>
-             <imagedata fileref="img/tempo_bar.png" format="PNG" />
+             <imagedata fileref="img/tag_bar.png" format="PNG" />
            </imageobject>
          </mediaobject>
-         </informalfigure>
-       </para>
-
-       <para>
-       In addition to changing the tempo when the song switches from intro > verse, 
-       it is also very handy to have a clear indication of this tempo switch (or any other
-       event in the song).  For this purpose you can also add Tags markers to the song.
-       These Tags are short text messages you can add to your song at any given 
-       moment that will be displayed whenever the song playhead passes by that Tag.</para>
-       </sect2>
+       </informalfigure>
        
-       <sect2 id="chpt.song_editor.timeline.tag">
-         <title>Tags</title>       
        <para>
-       To add a Tag to your song simply middle-click on the song ruler (just below the 
-       tempo ruler) and a window will pop up where that allows you to add text for any bar.
-            
-        <informalfigure id="fig.add_tag">
-         <mediaobject>
-           <imageobject>
-             <imagedata fileref="img/add_tag.png" format="PNG" />
-           </imageobject>
-          </mediaobject>
-         </informalfigure>
-
-       Once you are done you will see a small blue 'T' in the song ruler for every tag 
-       you have entered.  Middle-click anywhere on the song ruler to edit the tags.
-
-         <informalfigure id="fig.tag_bar">
-          <mediaobject>
-            <imageobject>
-              <imagedata fileref="img/tag_bar.png" format="PNG" />
-            </imageobject>
-          </mediaobject>
-         </informalfigure>
+         In addition to altering the tempo when the song switches from e.g. the intro into a verse, 
+         it is also very handy to have a clear indication of more general changes or special events in the song. For this purpose you can also add <emphasis>Tags</emphasis> to the song.
+         These Tags are short text messages you can add at any given 
+         moment that will be displayed whenever the song playhead passes by that Tag.
        </para>
-       </sect2>
+       
+       <para>
+         To add a Tag <keycap>middle-click</keycap> on the song ruler (just below the 
+         Timeline) and a window will pop up that allows you to add text for any bar.
+         
+         <informalfigure id="fig.add_tag">
+           <mediaobject>
+             <imageobject>
+               <imagedata fileref="img/add_tag.png" format="PNG" />
+             </imageobject>
+           </mediaobject>
+         </informalfigure>
+
+         Once you are done you will see a small blue <parameter>T</parameter> in the song ruler for every Tag
+         you have entered. <keycap>Middle-click</keycap> anywhere on the song ruler to edit the tags.
+       </para>
      </sect1>
 
      <sect1 id="chpt.song_editor.playbackTrack">
-		 <title>Playback Track</title>
-		 <para>This section describes how you can use a playback track to write drums for an existing track.
-				This useful when you want to write a drumtrack to an already existing instrumental track, for example a guitar track.
+	   <title>Playback Track</title>
+
+	   <informalfigure id="fig.playbackTrack">
+		 <mediaobject>
+		   <imageobject>
+			 <imagedata fileref="img/PlaybackTrack.png" format="PNG" />
+		   </imageobject>
+		 </mediaobject>
+	   </informalfigure>
+
+       
+	   <para>
+         Using the Playback Track you can program your song alongside an existing audio file, for example a guitar track.
 		 </para>
+
+		 <note>
+	       <para>
+			 When a Playback Track is loaded, it will be played back everytime audio transport in Hydrogen is rolling and <link linkend="sect.main_toolbar.transport_control">Song Mode</link> is activated. 
+           </para>
+         </note>
+
 		 <para>
-			To add a playback track to your song, you need to enable the playback track view. This can be done by pressing the small "P" button in the next to the vertical scroll bar of the song editor.
+		   To add a playback track to your song, you need to enable the playback track view. This can be done by either pressing the "P" button (TODO: use image) left to the scroll bar at the bottom of the Song Editor or via the <link linkend="sect.main_menu.view">View</link> element of the Main Menu.
+         </para>
 
-			 <informalfigure id="fig.enablePlaybackTrack">
-				 <mediaobject>
-					 <imageobject>
-						 <imagedata fileref="img/EnablePlaybackTrack.png" format="PNG" />
-					 </imageobject>
-				 </mediaobject>
-			 </informalfigure>
-
-			 An alternative way to enable the playback track view is to enable the option "Playback track" in the "View" menu.
-
-			 If the playback track view is enabled, a visualisation of the currently loaded track is display above the song editor.
-
-			 <informalfigure id="fig.playbackTrack">
-				 <mediaobject>
-					 <imageobject>
-						 <imagedata fileref="img/PlaybackTrack.png" format="PNG" />
-					 </imageobject>
-				 </mediaobject>
-			 </informalfigure>
-
-			Left to the visualisation, the controls for the playback are displayed:
+         <para>
+		   Left to the wave display, the controls of the Playback Track are displayed.
 
 			 <itemizedlist mark="opencircle">
 				 <listitem>
-				   <para><emphasis role="bold">Edit</emphasis>: load a new playback track</para>
+				   <para><emphasis role="bold">Edit</emphasis>: loads an audio file.</para>
+                   <tip>
+	                 <para>
+	                   As an alternative, you can load an audio file by dragging it into Hydrogen and dropping over the wave display.
+                     </para>
+                   </tip>
                  </listitem>
                  <listitem>
-				   <para><emphasis role="bold">Mute</emphasis>: mute the current playback track</para>
+				   <para><emphasis role="bold">Mute</emphasis>: mutes the Playback Track.</para>
                  </listitem>
                  <listitem>
-				   <para><emphasis role="bold">Fader</emphasis>: adjust the volume of the playback track</para>
+				   <para><emphasis role="bold">Fader</emphasis>: adjusts the volume. You can think of this fader as the mixer strip of the Playback Track. The resulting audio will be pass the <link linkend="sect.master">Master section</link> of the Mixer like any other strip too.</para>
 				 </listitem>
 			 </itemizedlist>
-
-			As an alternative to the use of the Edit Button, you can add a new playback track by drag'n'drop, just drag an audio file to the visualation area.
-			 When a playback track track is loaded, it will be played everytime Hydrogen is in "Play" mode and the song mode is activated. 
-		</para>
+         </para>
+         
+         <note>
+	       <para>
+	         In its current implementation the Playback Track does hide the song ruler used for navigation. It is therefore adviced to hide the Playback Track again once you are done setting the sound file and adjusting its volume.
+           </para>
+         </note>
+         
 	 </sect1>
+     
      <sect1 id="sect.song_editor.automation_path">
 	   <title>Automation Path</title>
+       
        <para>
 	     TODO
        </para>
+       
      </sect1>
    </chapter>
     

--- a/manual.docbook
+++ b/manual.docbook
@@ -246,15 +246,6 @@
 <!--   UI OVERVIEW  -->
     <chapter id="chpt.UIoverview">
       <title>Overview</title>
-
-      <para>The Main UI comes in 2 flavors : the (classic) Single Pane mode (ideal for
-      large- and medium size screens), and the Tabbed mode (optimized for netbook screen 
-      sizes).
-      </para>
-      <para>
-      Below you can see the main UI split up in 5 parts : the Main Menu, Main 
-      Toolbar, Song Editor, Pattern Editor and the Instrument and Sound Library Editor.
-        These sections will be explained in detail further down in this manual.</para>
       
       <figure id="fig.UI_overview">
         <title>The Main UI in Single Pane mode</title>
@@ -266,6 +257,17 @@
         </mediaobject>
       </figure>
 
+      <para>The Main UI comes in 2 flavors : the (classic) Single Pane mode (ideal for
+      large- and medium size screens), and the Tabbed mode (optimized for netbook screen 
+      sizes).
+      </para>
+      <para>
+      Below you can see the main UI split up in 5 parts : the Main Menu, Main 
+      Toolbar, Song Editor, Pattern Editor and the Instrument and Sound Library Editor.
+        These sections will be explained in detail further down in this
+        manual.
+      </para>
+      
       <figure id="fig.tabbed_UI_overview">
         <title>The Main UI in Tabbed mode</title>
 
@@ -288,6 +290,15 @@
       <sect1 id="chpt.preferences.general_tab">
         <title>General</title>
         
+        <figure id="fig.preferences.general_tab">
+          <title>The General Tab</title>
+          <mediaobject>
+            <imageobject>
+              <imagedata fileref="img/PreferencesGeneral_V3.png" format="PNG"/>
+            </imageobject>
+          </mediaobject>
+        </figure>
+        
         <para>On the "General" tab (<xref linkend="fig.preferences.general_tab"/>) you can 
         choose to automatically reopen the last used song and/or playlist.  This can save you 
         the trouble of having to reopen the song you are working on every time you open 
@@ -301,20 +312,20 @@
         you need to enter the path where rubberband is installed on you system here.</para>
         <!-- THIJS : NEED TO AD LINK TO SAMPLE EDITOR -->
         
-        <figure id="fig.preferences.general_tab">
-          <title>The General Tab</title>
-          <mediaobject>
-            <imageobject>
-              <imagedata fileref="img/PreferencesGeneral_V3.png" format="PNG"/>
-            </imageobject>
-          </mediaobject>
-        </figure>
-        
 
       </sect1>
 
       <sect1 id="chpt.preferences.audio_tab">
         <title>Audio System</title>
+
+        <figure id="fig.preferences.audio_tab">
+          <title>The Audio System Tab</title>
+          <mediaobject>
+            <imageobject>
+              <imagedata fileref="img/PreferencesAudioSystem_V3.png" format="PNG"/>
+            </imageobject>
+          </mediaobject>
+        </figure>
 
         <para>From the "Audio System" tab (<xref
         linkend="fig.preferences.audio_tab"/>) it is possible to modify the
@@ -327,15 +338,6 @@
         prevent hydrogen from overrunning the audio driver.</para>
         <para>The "Interpolate resampling" parameter allows you to select your preferred
         interpolation method.</para>
-
-        <figure id="fig.preferences.audio_tab">
-          <title>The Audio System Tab</title>
-          <mediaobject>
-            <imageobject>
-              <imagedata fileref="img/PreferencesAudioSystem_V3.png" format="PNG"/>
-            </imageobject>
-          </mediaobject>
-        </figure>
 
         <para>
           The following drivers are available:
@@ -452,6 +454,15 @@
       <sect1 id="chpt.preferences.midi_tab">
         <title>MIDI System</title>
 
+        <figure id="fig.preferences.midi_tab">
+          <title>The MIDI System Tab</title>
+          <mediaobject>
+            <imageobject>
+              <imagedata fileref="img/PreferencesMidiSystem_V2.png" format="PNG"/>
+            </imageobject>
+          </mediaobject>
+        </figure>
+
         <para>The "MIDI System" tab (<xref linkend="fig.preferences.midi_tab"/>)
         contains all <abbrev>MIDI</abbrev> settings. Here you can choose the <abbrev>MIDI</abbrev> driver (<abbrev>ALSA</abbrev>, PortMidi, 
         CoreMidi or JackMidi) input, and channel(s) that Hydrogen should respond to.  
@@ -469,20 +480,21 @@
         select with this midi action.
           </para>
         </note>
-       <para>See <xref linkend="chpt.midi"/> for more info on <abbrev>MIDI</abbrev> actions.</para>
-
-        <figure id="fig.preferences.midi_tab">
-          <title>The MIDI System Tab</title>
-          <mediaobject>
-            <imageobject>
-              <imagedata fileref="img/PreferencesMidiSystem_V2.png" format="PNG"/>
-            </imageobject>
-          </mediaobject>
-        </figure>
-      </sect1>
+       <para>See <xref linkend="chpt.midi"/> for more info on
+       <abbrev>MIDI</abbrev> actions.</para>
+     </sect1>
 
       <sect1 id="chpt.preferences.osc_tab">
         <title>OSC</title>
+
+        <figure id="fig.preferences.osc_tab">
+          <title>The OSC Tab</title>
+          <mediaobject>
+            <imageobject>
+              <imagedata fileref="img/PreferencesOSC.png" format="PNG"/>
+            </imageobject>
+          </mediaobject>
+        </figure>
 
         <para>The <abbrev>OSC</abbrev> tab (<xref linkend="fig.preferences.osc_tab"/>) let's
         you modify all options associated with <abbrev>OSC</abbrev> (Open Sound Control) (see
@@ -539,28 +551,10 @@
           in the <abbrev>OSC</abbrev> tab of the Preferences.
           </para>
         </note>
-
-        <figure id="fig.preferences.osc_tab">
-          <title>The OSC Tab</title>
-          <mediaobject>
-            <imageobject>
-              <imagedata fileref="img/PreferencesOSC.png" format="PNG"/>
-            </imageobject>
-          </mediaobject>
-        </figure>
       </sect1>
-
-
 
       <sect1 id="chpt.preferences.appearance_tab">
         <title>Appearance</title>
-
-        <para>The "Appearance" tab (<xref
-        linkend="fig.preferences.appearance_tab"/>) let's you modify Hydrogen look 
-        and feel (font settings and interface style). On this tab you can also change the 
-        VU meters fall-off speed and switch between Single pane and Tabbed interface
-        mode (see <xref linkend="chpt.UIoverview"/>)
-        </para>
 
         <figure id="fig.preferences.appearance_tab">
           <title>The Appearance Tab</title>
@@ -570,6 +564,13 @@
             </imageobject>
           </mediaobject>
         </figure>
+
+        <para>The "Appearance" tab (<xref
+        linkend="fig.preferences.appearance_tab"/>) let's you modify Hydrogen look 
+        and feel (font settings and interface style). On this tab you can also change the 
+        VU meters fall-off speed and switch between Single pane and Tabbed interface
+        mode (see <xref linkend="chpt.UIoverview"/>)
+        </para>
       </sect1>
 
     </chapter>
@@ -767,13 +768,6 @@
             <para><emphasis role="bold">Import</emphasis>: imports another drumkit from the local filesystem.
             </para>
             <para>
-              You can import existing drumkits from other users via <menuchoice>
-              <guimenu>Instruments</guimenu><guimenuitem>Import library</guimenuitem>
-              </menuchoice>.  The Import window will pop up with the Internet tab selected.
-              By default the link to the drumkit list (on hydrogen-music.org) will be filled in, 
-              and after pressing the 'Update list' button you will get a complete list of all
-              drumkits that are available for download.  In the status column you can see
-              if a kit is installed or not.
 
               <figure id="fig.import_drumkit">
                 <title>Import Drumkit</title>
@@ -783,6 +777,14 @@
                   </imageobject>
                 </mediaobject>
               </figure>
+              
+              You can import existing drumkits from other users via <menuchoice>
+              <guimenu>Instruments</guimenu><guimenuitem>Import library</guimenuitem>
+              </menuchoice>.  The Import window will pop up with the Internet tab selected.
+              By default the link to the drumkit list (on hydrogen-music.org) will be filled in, 
+              and after pressing the 'Update list' button you will get a complete list of all
+              drumkits that are available for download.  In the status column you can see
+              if a kit is installed or not.
             </para>
           </listitem>
           <listitem>
@@ -869,16 +871,7 @@
         <itemizedlist>
           <listitem id="chpt.preferences.audio_engine_tab">
             <para><emphasis role="bold">Show audio engine info</emphasis>: opens a window that shows
-            various stats about Hydrogen and the audio driver. In case <abbrev>JACK</abbrev> is used,
-            buffer and sampling rate should be set in the configuration of the <abbrev>JACK</abbrev>
-            server before starting Hydrogen (<abbrev>JACK</abbrev> automatically starts when an
-            application tries to connect).</para>
-            <note>
-              <para>
-                Note that the Audio Engine tab is only available if Hydrogen was compiled with 
-                debug support.
-              </para>
-            </note>
+            various stats about Hydrogen and the audio driver.
 
             <figure id="fig.preferences.audio_engine_tab">
               <title>The Audio Engine View</title>
@@ -888,6 +881,17 @@
                 </imageobject>
               </mediaobject>
             </figure>
+
+            In case <abbrev>JACK</abbrev> is used,
+            buffer and sampling rate should be set in the configuration of the <abbrev>JACK</abbrev>
+            server before starting Hydrogen (<abbrev>JACK</abbrev> automatically starts when an
+            application tries to connect).</para>
+            <note>
+              <para>
+                Note that the Audio Engine tab is only available if Hydrogen was compiled with 
+                debug support.
+              </para>
+            </note>
 
           </listitem>
           <listitem>
@@ -928,6 +932,16 @@
 <!--   MAIN TOOLBAR  -->
     <chapter id="chpt.main_toolbar">
       <title>Main Toolbar</title>
+      
+      <figure id="fig.main_toolbar">
+        <title>The Main Toolbar</title>
+        
+        <mediaobject>
+          <imageobject>
+            <imagedata fileref="img/MainToolbar_V2.png" format="PNG"/>
+          </imageobject>
+        </mediaobject>
+      </figure>
 
       <para>Before analyzing the two main frames of Hydrogen, let's take a quick
       look at the main toolbar and its components:</para>
@@ -962,23 +976,17 @@
 	    TODO: drop this apart from the image
       </para>
 
-      <figure id="fig.main_toolbar">
-        <title>The Main Toolbar</title>
-        
-        <mediaobject>
-          <imageobject>
-            <imagedata fileref="img/MainToolbar_V2.png" format="PNG"/>
-          </imageobject>
-        </mediaobject>
-      </figure>
-
       <sect1 id="sect.main_toolbar.transport_control">
         <title>
           Transport Control
         </title>
-        <para><inlinemediaobject><imageobject><imagedata
-        fileref="img/background_Control_V2.png" format="PNG"/>
-        </imageobject></inlinemediaobject></para>
+        <para>
+          <inlinemediaobject>
+            <imageobject>
+              <imagedata fileref="img/background_Control_V2.png" format="PNG"/>
+            </imageobject>
+          </inlinemediaobject>
+        </para>
 
           <para>Main controls to start <emphasis role="bold">[Hotkey =
           Spacebar]</emphasis>, stop, record, fast forward, rewind, loop a song or a
@@ -996,9 +1004,13 @@
 
       <sect1 id="sect.main_toolbar.tap_tempo_beat_counter">
         <title>Tap Tempo and Beat Counter</title>
-          <para><inlinemediaobject><imageobject>
-          <imagedata fileref="img/MeasureSettings.png" format="PNG"/>
-          </imageobject></inlinemediaobject></para>
+        <para>
+          <inlinemediaobject>
+            <imageobject>
+              <imagedata fileref="img/MeasureSettings.png" format="PNG"/>
+            </imageobject>
+          </inlinemediaobject>
+        </para>
 
           <para>Set measure type and Beat Counter (see <xref linkend="sect.main_toolbar.tap_tempo_beat_counter"/>).</para>
 
@@ -1101,9 +1113,13 @@
       </sect1>
       <sect1 id="sect.main_toolbar.bpm_control_and_metronome">
         <title>BPM Control and Metronome</title>
-          <para><inlinemediaobject><imageobject>
-            <imagedata fileref="img/background_BPM.png" format="PNG"/>
-          </imageobject></inlinemediaobject></para>
+        <para>
+          <inlinemediaobject>
+            <imageobject>
+              <imagedata fileref="img/background_BPM.png" format="PNG"/>
+            </imageobject>
+          </inlinemediaobject>
+        </para>
 
           <para>Set speed of playing (range: 30-400 bpm) <emphasis
           role="bold">[Hotkey = mouse wheel]</emphasis> and button to
@@ -1112,18 +1128,26 @@
 
       <sect1 id="sect.main_toolbar.cpu_usage_midi_in">
         <title>CPU Usage and MIDI in</title>
-          <para><inlinemediaobject><imageobject>
-          <imagedata fileref="img/MidiIN_CPU.png" format="PNG"/>
-          </imageobject></inlinemediaobject></para>
+        <para>
+          <inlinemediaobject>
+            <imageobject>
+              <imagedata fileref="img/MidiIN_CPU.png" format="PNG"/>
+            </imageobject>
+          </inlinemediaobject>
+        </para>
 
             <para>Shows CPU load and <abbrev>MIDI</abbrev> events.  The CPU bargraph gives you an indication of the CPU load.  The <abbrev>MIDI</abbrev> led lights up every time Hydrogen receives a midi message.</para>
       </sect1>
       
       <sect1 id="sect.main_toolbar.jack_control">
         <title>JACK Control</title>
-        <para><inlinemediaobject><imageobject>
-            <imagedata fileref="img/JackTrans_Master.png" format="PNG"/>
-          </imageobject></inlinemediaobject></para>
+        <para>
+          <inlinemediaobject>
+            <imageobject>
+              <imagedata fileref="img/JackTrans_Master.png" format="PNG"/>
+            </imageobject>
+          </inlinemediaobject>
+        </para>
 
           <para>Click J. TRANS to enable <abbrev>JACK</abbrev> transport.  If the J. MASTER
           button is pressed Hydrogen will work as <abbrev>JACK</abbrev> timebase 'master' by
@@ -1146,9 +1170,13 @@
       
         <sect1 id="sect.main_toolbar.gui_state">
           <title>GUI State</title>
-          <para><inlinemediaobject><imageobject>
-            <imagedata fileref="img/mixer-instrrack_btn.png" format="PNG"/>
-          </imageobject></inlinemediaobject></para>
+          <para>
+            <inlinemediaobject>
+              <imageobject>
+                <imagedata fileref="img/mixer-instrrack_btn.png" format="PNG"/>
+              </imageobject>
+            </inlinemediaobject>
+          </para>
 
           <para>
           The last section gives you quick access to the Mixer window and the Instrument Rack.
@@ -1162,14 +1190,7 @@
     <chapter id="chpt.song_editor">
       <title>Song Editor</title>
 
-      <para>The "Song Editor" (<xref linkend="fig.song_editor"/>) gives an
-      overview of the whole timeline of the song (e.g. intro, verse, bridge,
-      chorus and so on); each blue colored square on this panel represents a complete
-      bar as shown in the underlying "Pattern Editor" panel. The song editor gives
-      you complete freedom to add/remove patterns to the song and to move or 
-      copy any part of your song.
-      
-           
+      <para>
       <figure id="fig.song_editor">
         <title>The Song Editor</title>
         <mediaobject>
@@ -1180,6 +1201,14 @@
       </figure>
       </para>
 
+      <para>The "Song Editor" (<xref linkend="fig.song_editor"/>) gives an
+      overview of the whole timeline of the song (e.g. intro, verse, bridge,
+      chorus and so on); each blue colored square on this panel represents a complete
+      bar as shown in the underlying "Pattern Editor" panel. The song editor gives
+      you complete freedom to add/remove patterns to the song and to move or 
+      copy any part of your song.
+      </para>
+      
      <sect1 id="chpt.song_editor.main_controls">
       <title>Main Controls</title>
       <para>
@@ -1391,7 +1420,10 @@
      </sect1>
       
      <sect1 id="chpt.song_editor.timeline">
-     <title>Timeline</title>
+       <title>Timeline</title>
+       <para>
+	     TODO: add image of Timeline
+       </para>
        <para>This section describes how you can define tempo changes and 
        how you can add tags to your song.</para>
        <sect2 id="chpt.song_editor.timeline.tempo_marker">
@@ -1529,7 +1561,14 @@
     <chapter id="chpt.pattern_editor">
     
       <title>Pattern Editor</title>
-
+        <figure id="fig.PatternEditor_DrumMode">
+         <title>Pattern Editor in Drum Mode</title>
+         <mediaobject>
+           <imageobject>
+             <imagedata fileref="img/PatternEditor_DrumMode.png" format="PNG" />
+           </imageobject>
+         </mediaobject>
+        </figure>
       <para>The "Pattern Editor" 
       allows you to create or modify the selected pattern by adding/removing notes and tuning 
       a number of per-note properties like velocity and pan.
@@ -1550,22 +1589,11 @@
       
       </para>
       
-      <para>First let's take a look at the (classic) 'Drum' mode :
-        <figure id="fig.PatternEditor_DrumMode">
-         <title>Pattern Editor in Drum Mode</title>
-         <mediaobject>
-           <imageobject>
-             <imagedata fileref="img/PatternEditor_DrumMode.png" format="PNG" />
-           </imageobject>
-         </mediaobject>
-        </figure>
-      </para>
+      <para>First let's take a look at the (classic) 'Drum' mode.</para>
       
       <sect1 id="chpt.pattern_editor.controls"> 
-       
         <title>Controls</title>
-        <para>The top part of the pattern editor contains a number of controls :</para>
-      
+        
         <figure id="fig.PatternEditorControls">
          <title>Pattern Editor Controls</title>
          <mediaobject>
@@ -1574,7 +1602,9 @@
            </imageobject>
          </mediaobject>
         </figure>
-        
+
+        <para>The top part of the pattern editor contains a number of controls :</para>
+              
          <para>From left to right : </para>
          <itemizedlist mark="opencircle">
          
@@ -1650,18 +1680,19 @@
       </sect1>
       
       <sect1 id="chpt.pattern_editor.drumkit">
-      <title>Drumkit Editor</title>
-        <para>The section on the left shows you what drumkit is currently selected (GMkit by default) and below that you can see
-        the instruments that are part of this kit.</para>
+        <title>Drumkit Editor</title>
         
         <para>
-        <inlinemediaobject id="ifig.pattern_editor_instrument">
-          <imageobject>
-            <imagedata fileref="img/PatternEditorInstr_V2.png" format="PNG" />
-          </imageobject>
-        </inlinemediaobject>
+          <inlinemediaobject id="ifig.pattern_editor_instrument">
+            <imageobject>
+              <imagedata fileref="img/PatternEditorInstr_V2.png" format="PNG" />
+            </imageobject>
+          </inlinemediaobject>
         </para>
-          
+     
+        <para>The section on the left shows you what drumkit is currently selected (GMkit by default) and below that you can see
+        the instruments that are part of this kit.</para>
+     
         <para>Each instrument has its own set of features that are accessible by 
         right-clicking the instrument.  From the context menu that pops up you can select </para>
         <itemizedlist mark="opencircle"> 
@@ -1807,7 +1838,10 @@
       </sect1>
       
       <sect1 id="chpt.pattern_editor.note_properties">
-      <title>Note Properties Editor</title>
+        <title>Note Properties Editor</title>
+        <para>
+	      TODO: add image of note properties editor (velocity)
+        </para>
       <para>Clicking on an instrument or adding/removing a note next to it 
       will select this instrument.  Once an instrument is selected the note properties 
       for this instrument will be shown in the form of vertical lines in the bottom window.  
@@ -1940,12 +1974,8 @@
       </sect1>
 
       <sect1 id="chpt.pattern_editor.piano_mode">
-      <title>Piano Mode Editor</title>
-      <para>Drum mode (see <xref linkend="fig.PatternEditor_DrumMode"/>) focuses on using Hydrogen as a drum machine.
-      If you are using Hydrogen as an instrument there is a big chance that the Piano mode is for you.
-      It gives you a complete 'piano keyboard' so you can easily put down your tunes.</para>
-      <para>You can compare the Piano mode to the Note properties Notekey (described above), only here you have a 
-      complete piano keyboard, so you don't have to select the octave first.</para>
+        <title>Piano Mode Editor</title>
+        
        <figure id="fig.PatternEditor_PianoMode">
          <title>Pattern Editor in Piano Mode</title>
          <mediaobject>
@@ -1953,7 +1983,15 @@
              <imagedata fileref="img/PatternEditor_PianoMode.png" format="PNG" />
            </imageobject>
          </mediaobject>
-        </figure>
+       </figure>
+       
+       <para>Drum mode (see <xref linkend="fig.PatternEditor_DrumMode"/>) focuses on using Hydrogen as a drum machine.
+       If you are using Hydrogen as an instrument there is a big chance that the Piano mode is for you.
+       It gives you a complete 'piano keyboard' so you can easily put down your tunes.</para>
+       <para>You can compare the Piano mode to the Note properties Notekey (described above), only here you have a 
+       complete piano keyboard, so you don't have to select the octave
+       first.</para>
+      
       </sect1>
      
     </chapter>
@@ -1961,6 +1999,15 @@
   <chapter id="chpt.sound_library" xreflabel="Instrument rack">
     <title>Sound Library (Drumkit/Pattern/Song Manager)</title>
 
+      <figure id="fig.soundlibrary">
+        <title>The Soundlibrary</title>
+        <mediaobject>
+          <imageobject>
+            <imagedata fileref="img/SoundLibrary.png" format="PNG" />
+          </imageobject>
+        </mediaobject>
+      </figure>
+      
     <para>
 	  TODO: split into conceptual part and one that deals with the actual user interface
     </para>
@@ -1999,14 +2046,6 @@
       favourite patterns, and favourite songs.  When making new songs and new drum
       kits, it allows you to reuse and mix the instruments and patterns from other kits and songs.
 
-      <figure id="fig.soundlibrary">
-        <title>The Soundlibrary</title>
-        <mediaobject>
-          <imageobject>
-            <imagedata fileref="img/SoundLibrary.png" format="PNG" />
-          </imageobject>
-        </mediaobject>
-      </figure>
       </para>
 
       <sect1 id="sect.systemdrumkits">
@@ -2210,10 +2249,6 @@
       </sect1>      
       <sect1 id="chpt.instrument_editor.general">
         <title>General</title>
-
-        <para>In the instrument editor, click on the
-        <guibutton>General</guibutton> button.  Here you can adjust several
-        parameters that apply to the instrument (applies to all layers as well).
         
         <figure id="instrumenteditor.general">
         <title>The Instrument editor General view</title>
@@ -2223,8 +2258,12 @@
           </imageobject>
         </mediaobject>
         </figure>
-        
+
+        <para>In the instrument editor, click on the
+        <guibutton>General</guibutton> button.  Here you can adjust several
+        parameters that apply to the instrument (applies to all layers as well).      
         The parameters are:</para>
+        
         <itemizedlist>
           <listitem>
             <para><emphasis role="bold">Envelope parameters</emphasis>:
@@ -2491,6 +2530,15 @@
       
       <sect1 id="chpt.instrument_editor.layers">
         <title>Layers</title>
+        
+        <figure id="instrumenteditor.layers">
+        <title>The Instrument Editor Layers View</title>
+        <mediaobject>
+          <imageobject>
+            <imagedata fileref="img/Instrument_Layers.png" format="PNG" />
+          </imageobject>
+        </mediaobject>
+        </figure>
 
         <para>For each instrument in a drum kit, you can load several samples
         and set different synthesizer parameters.  This section will step you
@@ -2535,15 +2583,6 @@
         the sides of the light blue rectangles and you see that you get a
         left-right drag cursor.  Now drag the sample to the left or right (like
         a curtain).  You will now see Layer 2 appear.</para>
-        
-        <figure id="instrumenteditor.layers">
-        <title>The Instrument Editor Layers View</title>
-        <mediaobject>
-          <imageobject>
-            <imagedata fileref="img/Instrument_Layers.png" format="PNG" />
-          </imageobject>
-        </mediaobject>
-        </figure>
 
         <para>The velocity setting for the layer is 0-velocity on the left, and
         full velocity on the right.  Set up Layer 1 to sound for soft notes, and
@@ -2640,14 +2679,15 @@
 
     
       <chapter id="chpt.sample_editor">
-        <title>Sample Editor</title>        
+        <title>Sample Editor</title>
+        
         <figure id="sample.editor">
-        <title>The Sample Editor</title>
-        <mediaobject>
-          <imageobject>
-            <imagedata fileref="img/SampleEditor_V5.png" format="PNG" />
-          </imageobject>
-        </mediaobject>
+          <title>The Sample Editor</title>
+          <mediaobject>
+            <imageobject>
+              <imagedata fileref="img/SampleEditor_V5.png" format="PNG" />
+            </imageobject>
+          </mediaobject>
         </figure>        
 
         <para>So far we have created a multilayered Drumkit, set a number of 
@@ -2772,14 +2812,6 @@
     <chapter id="chpt.mixer" xreflabel="Mixer">
       <title>Mixer</title>
 
-      <para>The Mixer window can be opened by pressing Alt+M, by clicking 
-      Mixer in the Tools menu, or by clicking the Mixer button on the main toolbar.
-      </para>
-      <para>The Mixer consists of 3 sections (left>right) : the instrument channel strips, 
-      the FX plugin rack and the master fader section.  The Hydrogen Mixer works very
-       much like a hardware mixer does : it lets you set the volume, pan, FX and several 
-       other things for every instrument.
-
       <figure id="fig.mixer">
         <title>The Mixer</title>
         <mediaobject>
@@ -2788,6 +2820,14 @@
           </imageobject>
         </mediaobject>
       </figure>
+
+      <para>The Mixer window can be opened by pressing Alt+M, by clicking 
+      Mixer in the Tools menu, or by clicking the Mixer button on the main toolbar.
+      </para>
+      <para>The Mixer consists of 3 sections (left>right) : the instrument channel strips, 
+      the FX plugin rack and the master fader section.  The Hydrogen Mixer works very
+       much like a hardware mixer does : it lets you set the volume, pan, FX and several 
+       other things for every instrument.
       </para>
 
     <sect1 id="chpt.mixer.channel_strips">
@@ -3138,10 +3178,8 @@
     
    <chapter id="chpt.director" xreflabel="Director">
      <title>Director</title>
-     <para>
-       Now all we need is a way to see the tags we have entered.  This can be done
-       using the Director window.  Open the Director by pressing Alt-D, or Tools- Director :
 
+     <para>
        <informalfigure id="fig.director">
          <mediaobject>
            <imageobject>
@@ -3149,6 +3187,11 @@
            </imageobject>
          </mediaobject>
        </informalfigure>
+     </para>
+     
+     <para>
+       Now all we need is a way to see the tags we have entered.  This can be done
+       using the Director window.  Open the Director by pressing Alt-D, or Tools- Director.
        
        The Director is your best friend when you need a quick overview of what Hydrogen
        is currently doing.  This comes in very handy when you are recording a song, or

--- a/manual.docbook
+++ b/manual.docbook
@@ -33,12 +33,6 @@
     </abstract>
   </bookinfo>
 
-  <!--
-      ###################
-      # FIRST CHAPTER   #
-      ###################
-  -->
-
   <part id="part.1">
     <title>Introduction</title>
 
@@ -188,12 +182,12 @@
       <itemizedlist>
 	    <listitem>
 	      <para>
-	        <keycap>Ctrl</keycap> + <keycap>left click</keycap>: restore default value of knob or fader
+	        <keycap>Ctrl</keycap> + <keycap>left click</keycap> : restore default value of knob or fader
           </para>
         </listitem>
         <listitem>
 	      <para>
-	        <keycap>Shift</keycap> + <keycap>left click</keycap>: bind <abbrev>MIDI</abbrev> event to <abbrev>MIDI</abbrev>-learnable widget (see <xref linkend="chpt.midi.learnable"/>
+	        <keycap>Shift</keycap> + <keycap>left click</keycap> : bind <abbrev>MIDI</abbrev> event to <abbrev>MIDI</abbrev>-learnable widget (see <xref linkend="chpt.midi.learnable"/>
           </para>
         </listitem>
       </itemizedlist>
@@ -340,7 +334,33 @@
         and if you want to use rubberband for sample time-stretching (see <xref linkend="chpt.sample_editor.section2"/>)
         you need to enter the path where rubberband is installed on you system here.</para>
         <!-- THIJS : NEED TO AD LINK TO SAMPLE EDITOR -->
-        
+
+
+        <itemizedlist>
+          <listitem><para><emphasis role="bold"><guilabel>Beat counter drift
+          compensation in 1/10ms</guilabel></emphasis> &mdash; adjust to
+          compensate for latency between the keyboard and the
+          program.</para></listitem>
+
+          <listitem><para><emphasis role="bold"><guilabel>Beat counter start
+          offset in ms</guilabel></emphasis> &mdash; adjust the time between the
+          Beat Counter's last input stroke and when the song starts playing (if
+          auto-start is activated).</para></listitem>
+        </itemizedlist>
+
+        <note>
+          <para>
+            Note that these can be set to positive (+) or negative (-) values.
+        In order to find useful values for these, you will need to take some
+        time to play with it.  Also, you may want different values depending on
+        the speed of your hardware, audio devices, drivers, etc.  Using the
+        Beat Counter effectively requires practice.
+          </para>
+        </note>
+
+        <para>
+	      TODO: fuse
+        </para>
 
       </sect1>
 
@@ -385,7 +405,7 @@
             recommended for beginners.</para>
           </listitem>
 
-          <listitem>
+          <listitem id="sect.preferences.jack">
             <para><emphasis role="bold">JACK</emphasis>: The <abbrev>JACK</abbrev> driver is a
             professional audio server which permits very low lag and exchanges
             with other audio software. <emphasis>We strongly recommend using
@@ -411,7 +431,7 @@
                   <listitem><para>layer gain</para></listitem>
                 </itemizedlist>
               </listitem>
-              <listitem>
+              <listitem id="sect.preferences.jack.bbt">
                 <para><emphasis role="bold">BBT sync method</emphasis>: If
                 Hydrogen uses <abbrev>JACK</abbrev> transport in the presence of an external <abbrev>JACK</abbrev>
                 Timebase master (TBM), it will use the provided measure and
@@ -433,6 +453,12 @@
                 be activated and the J. MASTER button deactivated (next to
                 having a <abbrev>JACK</abbrev> TBM application). See <xref
                 linkend="chpt.main_toolbar"/>.</para>
+
+                <tip>
+	              <para>
+	                Hydrogen can be registered as <abbrev>JACK</abbrev> Timebase Master via the <link linkend="sect.main_toolbar.jack_control">Main Toolbar</link>.
+                  </para>
+                </tip>
               </listitem>
               <listitem>
                 <para><emphasis role="bold">Connect to Default Output
@@ -977,42 +1003,13 @@
       </figure>
 
       <para>Before analyzing the two main frames of Hydrogen, let's take a quick
-      look at the main toolbar and its components:</para>
-
-      <itemizedlist>
-        <listitem>
-          <para>Pilot the song using the start, stop, pause, etc. buttons</para>
-        </listitem>
-        <listitem>
-          <para>Choose between "pattern" or "song" mode: in "pattern" mode only
-          the currently selected pattern will play, while in "song" mode all
-          patterns inserted will be played.</para>
-        </listitem>
-        <listitem>
-          <para>An advanced tap tempo function: choose note length and how many
-          notes to wait before recalculating BPM, then hit the comma key
-          repeatedly until the 'R' letter appears and then the BPM will be
-          updated.  (see <xref linkend="sect.main_toolbar.tap_tempo_beat_counter"/>)</para>
-        </listitem>
-        <listitem>
-          <para>Manually set BPM</para>
-        </listitem>
-        <listitem>
-          <para>Manage <abbrev>JACK</abbrev> transport</para>
-        </listitem>
-        <listitem>
-          <para>Open the mixer and the instrument rack panels</para>
-        </listitem>
-      </itemizedlist>
-
-      <para>
-	    TODO: drop this apart from the image
-      </para>
-
+      look at the main toolbar and its components</para>
+      
       <sect1 id="sect.main_toolbar.transport_control">
         <title>
           Transport Control
         </title>
+        
         <para>
           <inlinemediaobject>
             <imageobject>
@@ -1021,18 +1018,19 @@
           </inlinemediaobject>
         </para>
 
-          <para>Main controls to start <emphasis role="bold">[Hotkey =
-          Spacebar]</emphasis>, stop, record, fast forward, rewind, loop a song or a
-          pattern.</para>
+          <para>Main controls to start (also bound to <keycap>Space</keycap>), stop, record, fast forward, rewind, loop a song or a
+          pattern and to switch between Song mode and Pattern mode.</para>
 
-          <para>Set Pattern/Song Mode. When Song mode is selected Hydrogen will play 
-          the complete song. This is the sequence of patterns you have created in the Song 
-          Editor (see <xref linkend="chpt.song_editor"/>). When Pattern mode is selected 
+          <para>Set Pattern/Song Mode. When <emphasis>Song mode</emphasis> is selected Hydrogen will play 
+          the complete song. This is the sequence of patterns you have created in the <link linkend="chpt.song_editor">Song Editor</link>. When <emphasis>Pattern mode</emphasis> is selected 
           Hydrogen will play the pattern that is currently selected, and thus displayed 
-          in the Pattern Editor (see <xref
-          linkend="chpt.pattern_editor"/>).</para>
+          in the <link linkend="chpt.pattern_editor">Pattern Editor</link>.</para>
 
-          <para>TODO: update image and fuse pattern/song mode</para>
+          <para>
+	        When using the <link linkend="chpt.keyboard_and_mouse">Keyboard</link> to navigate in the <link linkend="chpt.song_editor">Song Editor</link> and <link linkend="chpt.pattern_editor">Pattern Editor</link> the shortcut <keycap>Ctrl</keycap> + <keycap>Space</keycap> (or <keycap>Alt</keycap> + <keycap>Space</keycap> on MacOS) will change the mode to the one corresponding to the editor. In addition, it will move the current transport position to either the note (Pattern Editor) or the pattern (Song Editor) focused by the cursor and starts the playback.
+          </para>
+
+          <para>TODO: update image</para>
       </sect1>
 
       <sect1 id="sect.main_toolbar.tap_tempo_beat_counter">
@@ -1045,50 +1043,48 @@
           </inlinemediaobject>
         </para>
 
-          <para>Set measure type and Beat Counter (see <xref linkend="sect.main_toolbar.tap_tempo_beat_counter"/>).</para>
+          <para>Set measure type and Beat Counter.</para>
 
         <para>It is possible to change the tempo at any time using the Tap Tempo and
-        BeatCounter features of Hydrogen.  You can do this while the song is playing or
+        Beat Counter features of Hydrogen.  You can do this while the song is playing or
         while the song is stopped.  To change the tempo, hit the
         <keycap>,</keycap> (comma) key in the tempo you want.
-        After the correct number of keystrokes have been detected (see 
+        After the correct number of keystrokes has been detected (see 
         below for details), the tempo will change to the average tempo 
-        you tapped the comma key.  If you continue to tap,
+        you tapped the <keycap>,</keycap> key.  If you continue to tap,
         these new taps will become a part of a rolling average.  If you tap
-        accidentally, or if you wait too long between taps, the tap tempo
+        accidentally, or if you wait too long between taps, the Tap Tempo
         counter will start over.</para>
 
-        <para>The Tap Tempo is a part of the BeatCounter, which is essentially a
-        Tap Tempo on steroids.  By default the BeatCounter display is not
-        visible.  To see the BeatCounter widget click the upright button
-        (<guilabel>BC</guilabel>) between Song/Pattern mode selector and the
-        BPM-widget, or, simply press the comma key.
-        (<keycap>,</keycap>).</para>
+        <para>The Tap Tempo is a part of the Beat Counter, which is essentially a
+        Tap Tempo on steroids.  By default the Beat Counter display is not
+        visible.  To see the Beat Counter widget click the upright button (TODO: insert image here)
+        (<guilabel>BC</guilabel>) or simply press <keycap>,</keycap>.</para>
 
         <para>The tempo that you tap will be considered even beats of the song's 
         beat type.  The beat type can be set to 1/8 (for eight-note beats), 1/4 (for
         quarter-note beats), 1/2 (for half-note beats), and 1/1 (for whole-note
-        beats).  To change the beat type use the left +/- buttons.  To change
-        the Countdown Counter value, use the right +/- buttons.  The Countdown 
+        beats).  To change the beat type use the left +/- (TODO: insert images here) buttons.  To change
+        the Countdown Counter value, use the right +/- (TODO: and here) buttons.  The Countdown 
         Counter value can be set between 2 and 16 beats.  (I.e. if you set the beat to 6, you will
         have to tap 6 times before the new tempo is computed and set.)  When the
-        display shows an <guilabel>R</guilabel>, it means that the BeatCounter
-        is ready to start from 0.  When you tap the comma key, the R will change to
+        display shows an <parameter>R</parameter>, it means that the Beat Counter
+        is ready to start from 0.  When you tap <keycap>,</keycap>, the <parameter>R</parameter> will change to
         1, and will increment with every keystroke until it reaches the Countdown 
-        Counter value (shown just below the 'R').</para>
+        Counter value (shown just below the <parameter>R</parameter>).</para>
 
         <para>The button in the bottom right-hand controls the auto-start
-        feature, and it toggles between <guilabel>S</guilabel> and
-        <guilabel>P</guilabel>.  When it shows <guilabel>P</guilabel> for
+        feature, and it toggles between <parameter>S</parameter> and
+        <parameter>P</parameter>.  When it shows <parameter>P</parameter> for
         (<emphasis>Play</emphasis>), the song will set the new tempo and
         automatically start to play after you tap the right number of beats (if
         it's not already playing, of course).  This way, if you have the
-        BeatCounter set up for 4/4, you can tap 1-2-3-4, and start playing on
-        the next beat.  When it shows <guilabel>S</guilabel> (for <emphasis>Set
+        Beat Counter set up for 4/4, you can tap 1-2-3-4, and start playing on
+        the next beat.  When it shows <parameter>S</parameter> (for <emphasis>Set
         BPM</emphasis>), the auto-start is disabled.</para>
 
         <para>For example: Suppose you have a live band, Hydrogen, and a
-        softsynth that is controlled by Seq24)... and you want them all to start
+        softsynth that is controlled by <command>Seq24</command>)... and you want them all to start
         at the same time.  Set the beat type to 1/4 and the number of beats to
         4.  Enable auto-start (button shows <guilabel>P</guilabel>).  Count off
         the band 1-2-3-4 (while tapping the comma key) &mdash; and everyone
@@ -1100,49 +1096,19 @@
         Hydrogen is supposed to play, tap the comma key 1-2-3-4 with the
         beat... and you're in on the next beat (at the right tempo).</para>
 
-        <para>If you are using the <abbrev>JACK</abbrev> Transport, the BeatCounter continues to
-        work.  If another program is the <abbrev>JACK</abbrev> Transport Master, Hydrogen will
-        respond to tempo change events from that application.
-        </para>
-        <note>
-          <para>
-            Please note that in this
-        situation, Hydrogen is supposed to be a <emphasis>slave</emphasis>, so
-        some of the BeatCounter features will be disabled or will not work
-        properly.  If Hydrogen is the <abbrev>JACK</abbrev> Transport Master, tempo changes from
-        Hydrogen will be reflected in those programs (if they support
-        it).
+        <tip>
+          <para>A start offset and a latency compensation for the Beat Counter can be configured in the <link linkend="chpt.preferences.general_tab">General tab</link> of the Preferences Dialog.
           </para>
-        </note>
-
-        <para>Some of the settings to adjust the BeatCounter's latency
-        compensation, are located on the General tab of the Preferences Dialog 
-        (see <xref linkend="chpt.preferences.general_tab"/>
-        ). Here you will find two spinboxes:</para>
-
-        <itemizedlist>
-          <listitem><para><emphasis role="bold"><guilabel>Beat counter drift
-          compensation in 1/10ms</guilabel></emphasis> &mdash; adjust to
-          compensate for latency between the keyboard and the
-          program.</para></listitem>
-
-          <listitem><para><emphasis role="bold"><guilabel>Beat counter start
-          offset in ms</guilabel></emphasis> &mdash; adjust the time between the
-          BeatCounter's last input stroke and when the song starts playing (if
-          auto-start is activated).</para></listitem>
-        </itemizedlist>
+        </tip>
 
         <note>
           <para>
-            Note that these can be set to positive (+) or negative (-) values.
-        In order to find useful values for these, you will need to take some
-        time to play with it.  Also, you may want different values depending on
-        the speed of your hardware, audio devices, drivers, etc.  Using the
-        BeatCounter effectively requires practice.
+            If you are using <abbrev>JACK</abbrev> transport in the presence of an external <link linkend="sect.preferences.jack.bbt"><abbrev>JACK</abbrev> Timebase Master</link>, Hydrogen is supposed to be a <emphasis>slave</emphasis> and the Beat Counter will be disabled. If Hydrogen itself is the <abbrev>JACK</abbrev> Transport Master, tempo changes from
+        Hydrogen will be broadcasted to other <abbrev>JACK</abbrev> clients.
           </para>
         </note>
 
-        <para>TODO: rework</para>
+        <para>TODO: since the Tap Tempo is a subset of the Beat Counter and both are bound to the same key and triggered by the same API function: Is there actually a separate Tap Tempo or can it be dropped since it was superseded by the Beat Counter a long time ago?</para>
       </sect1>
       <sect1 id="sect.main_toolbar.bpm_control_and_metronome">
         <title>BPM Control and Metronome</title>
@@ -1154,9 +1120,23 @@
           </inlinemediaobject>
         </para>
 
-          <para>Set speed of playing (range: 30-400 bpm) <emphasis
-          role="bold">[Hotkey = mouse wheel]</emphasis> and button to
-          enable/disable metronome</para>
+        <para>Set the speed of the song (range: 10-400 bpm).
+        </para>
+        
+          <tip>
+	        <para>
+	          You can use the <emphasis>mouse wheel</emphasis> to decrease and increase the value of this widget.
+            </para>
+          </tip>
+
+          <para>In addition you can use (TODO: insert button image) to toggle the metronome.</para>
+
+        <tip>
+	      <para>
+	        The volume of the metronome can be adjusted in the <link linkend="chpt.preferences.audio_tab">Audio tab</link> of the Preferences.
+          </para>
+        </tip>
+        
       </sect1>
 
       <sect1 id="sect.main_toolbar.cpu_usage_midi_in">
@@ -1169,7 +1149,14 @@
           </inlinemediaobject>
         </para>
 
-            <para>Shows CPU load and <abbrev>MIDI</abbrev> events.  The CPU bargraph gives you an indication of the CPU load.  The <abbrev>MIDI</abbrev> led lights up every time Hydrogen receives a midi message.</para>
+            <para>The CPU bargraph gives you an indication of the CPU load. The <abbrev>MIDI</abbrev> led lights up every time Hydrogen receives a midi message.</para>
+
+        <tip>
+	      <para>
+	        The <abbrev>MIDI</abbrev> settings can be adjusted in the <link linkend="chpt.preferences.midi_tab">MIDI tab</link> of the Preferences.
+          </para>
+        </tip>
+        
       </sect1>
       
       <sect1 id="sect.main_toolbar.jack_control">
@@ -1182,23 +1169,25 @@
           </inlinemediaobject>
         </para>
 
-          <para>Click J. TRANS to enable <abbrev>JACK</abbrev> transport.  If the J. MASTER
-          button is pressed Hydrogen will work as <abbrev>JACK</abbrev> timebase 'master' by
-          sending additional information, like the current speed, to other <abbrev>JACK</abbrev>
-          clients. Else it will either act as 'slave' in the presence of another
-          timebase master (e.g. Ardour) or as a stand-alone client in the
-          absence of it.
+        <para>Clicking J. TRANS (TODO: insert image instead) will enable <abbrev>JACK</abbrev> transport. If disabled, Hydrogen will still use the <abbrev>JACK</abbrev> driver and registered audio ports. But it decouples its own transport state from the one of the JACK server and will not be in sync with other clients anymore.
+        </para>
+        <para>
+          Using J. MASTER (TODO: insert image) Hydrogen can be registered as <abbrev>JACK</abbrev> Timebase Master and will send additional information, like the current speed, to other <abbrev>JACK</abbrev>
+          clients. Else it will either act as <emphasis>slave</emphasis> in the presence of another
+          Timebase Master, like <command>Ardour</command>, or as a stand-alone client in the
+          absence of a Master.
           </para>
-          <note>
+          <tip>
             <para>
-            Please note that when acting as 'slave' Hydrogen will obey the tempo
-            provided by the timebase master and instead of its own tempo markers
-            (see <xref linkend="chpt.preferences.audio_tab"/>).
+            You can check whether Hydrogen is in <emphasis>slave</emphasis> mode by hovering over the disabled <link linkend="sect.main_toolbar.tap_tempo_beat_counter">Beat Counter</link> or <link linkend="chpt.song_editor.timeline">Timeline</link>.
+            </para>
+          </tip>
+
+          <note>
+	        <para>
+	          The support of <abbrev>JACK</abbrev> Timebase can disabled in the <link linkend="chpt.preferences.audio_tab">Audio tab</link> of the Preferences. This can be useful in the presence of a fault Master broadcasting nuissance information.
             </para>
           </note>
-          <para>
-	        TODO: put all the JACK stuff in here.
-          </para>
       </sect1>
       
         <sect1 id="sect.main_toolbar.gui_state">
@@ -1212,8 +1201,14 @@
           </para>
 
           <para>
-          The last section gives you quick access to the Mixer window and the Instrument Rack.
-            The LCD screen displays what Hydrogen is up to.
+	        TODO: update image
+          </para>
+
+          <para>
+            Toggles the <link linkend="chpt.mixer">Mixer</link> window and the Instrument Rack (containing both the <link linkend="chpt.instrument_editor">Instrument Editor</link> and the <link linkend="chpt.sound_library">Sound Library</link>).
+          </para>
+          <para>
+            The LCD screen below displays what Hydrogen is up to and gives an optical feedback of the parameters set in the <link linkend="chpt.mixer">Mixer</link>.
           </para>
         </sect1>
     </chapter>


### PR DESCRIPTION
- all custom windows accessible via the main menu are listed in the main menu section
- all standalone widgets and bigger parts of the main window have their own section
- the second part of the manual should only contain technical information required to understand the GUI and the practical tips and example usage should be moved to the third part
- in the parts of the manual describing individual windows the screenshot of these windows has been moved to the top of the chapter/section