### PR TITLE
Rescaling images

### DIFF
--- a/res/docbook.css
+++ b/res/docbook.css
@@ -1900,6 +1900,14 @@ abbr {
   letter-spacing: 1px;
 }
 
+.figure img {
+  width: 100%;
+}
+
+.mediaobject > img:hover, .mediaobject > img:active {
+  width: unset;
+}
+
 /* ============================================================ */
 
 @media screen and (max-width: 1199px) {

--- a/res/docbook.css
+++ b/res/docbook.css
@@ -1863,6 +1863,8 @@ abbr {
 }
 
 img {
+  width: auto;
+  height: auto;
   max-width: 100%;
   transition: 0.3s;
   cursor: pointer;
@@ -1874,19 +1876,10 @@ img {
 }
 
 .figure-contents > .mediaobject {
+  z-index: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-}
-
-.figure-contents > .mediaobject:active, .informalfigure:active, .inlinemediaobject:active {
-  background-color: rgba(0,0,0,0.9);
-  top: 0;
-  left: 0;
-  z-index: 1;
-  position: fixed;
-  width: 100vw;
-  height: 100vh;
 }
 
 .figure-contents > .mediaobject > img {
@@ -1894,12 +1887,8 @@ img {
 
 }
 
-.figure-contents > .mediaobject > img:active, .informalfigure > img:active, .inlinemediaobject > img:active {
-  width: auto;
-  height: auto;
-  margin: auto;
-  max-height: 95%;
-  max-width: 95%;
+.figure-contents > .mediaobject > img, .informalfigure > img, .inlinemediaobject > img {
+    padding: 0em;
 }
 
 .informalfigure {
@@ -1908,14 +1897,6 @@ img {
   justify-content: start;
 }
 
-.inlinemediaobject:active {
-  display: flex;
-  align-items: center;
-}
-
-.informalfigure:active, .inlinemediaobject:active {
-  justify-content: center;
-}
 
 .informalfigure > img {
   max-height: 8.75rem;

--- a/res/docbook.css
+++ b/res/docbook.css
@@ -141,7 +141,6 @@
   --on-js-controls-color: var(--on-surface-color);
 
   --line-height: 1.75rem;
-  --image-max-height: 35rem; // Make the image at most 20 lines high
 }
 
 /* These choices are inspired by the material design system. Someone
@@ -372,6 +371,11 @@ pre code {
   padding: inherit;
   font-size: inherit;
   margin: inherit;
+}
+
+pre.screen {
+  display: block;
+  overflow-x: scroll;
 }
 
 .userinput {
@@ -1847,55 +1851,10 @@ body {
   grid-column-start: 2;
 }
 
-/* ============================================================ */
-/* For progressive reveals in chunked content. */
+//////////////////////////////////////////////////////////////////////
+/////////////////////////////// Hydrogen custom //////////////////////
+//////////////////////////////////////////////////////////////////////
 
-
-.reveal {
-  display: none;
-}
-
-ul.reveal,
-ol.reveal {
-  display: block;
-}
-
-.reveal > li {
-  display: none;
-}
-
-.reveal > li:first-child {
-  display: list-item;
-}
-
-.noreveal {
-  display: inherit;
-}
-
-.speaker-notes .reveal {
-  display: inherit;
-  background-color: #ffeeee;
-}
-
-.speaker-notes ul.reveal,
-.speaker-notes ol.reveal {
-  display: block;
-  background-color: #ffeeee;
-}
-
-.speaker-notes .reveal > li {
-  display: list-item;
-  background-color: #ffeeee;
-}
-
-.speaker-notes li.reveal {
-  display: list-item;
-  background-color: #ffeeee;
-}
-
-.speaker-notes .transitory {
-  display: none;
-}
 
 abbr {
   font-family: var(--mono-family);
@@ -1903,21 +1862,24 @@ abbr {
   letter-spacing: 1px;
 }
 
-.figure img {
+img {
   max-width: 100%;
-  max-height: var(--image-max-height);
   transition: 0.3s;
   cursor: pointer;
   border-radius: 5px;
 }
 
-.mediaobject {
+.inlinemediaobject > img {
+  max-height: 1.75rem;
+}
+
+.figure-contents > .mediaobject {
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.mediaobject:active {
+.figure-contents > .mediaobject:active, .informalfigure:active, .inlinemediaobject:active {
   background-color: rgba(0,0,0,0.9);
   top: 0;
   left: 0;
@@ -1927,14 +1889,38 @@ abbr {
   height: 100vh;
 }
 
-.mediaobject > img:active {
+.figure-contents > .mediaobject > img {
+  max-height: 31.5rem;
+
+}
+
+.figure-contents > .mediaobject > img:active, .informalfigure > img:active, .inlinemediaobject > img:active {
   width: auto;
   height: auto;
   margin: auto;
-  max-height: 90%;
-  max-width: 90%;
+  max-height: 95%;
+  max-width: 95%;
 }
 
+.informalfigure {
+  display: flex;
+  align-items: center;
+  justify-content: start;
+}
+
+.inlinemediaobject:active {
+  display: flex;
+  align-items: center;
+}
+
+.informalfigure:active, .inlinemediaobject:active {
+  justify-content: center;
+}
+
+.informalfigure > img {
+  max-height: 8.75rem;
+  max-width: 70%;
+}
 /* ============================================================ */
 
 @media screen and (max-width: 1199px) {

--- a/res/docbook.css
+++ b/res/docbook.css
@@ -139,6 +139,9 @@
   --js-controls-header-separator-border-style: 1px solid var(--popup-annotation-border-color);
   --js-controls-color: var(--surface-color);
   --on-js-controls-color: var(--on-surface-color);
+
+  --line-height: 1.75rem;
+  --image-max-height: 35rem; // Make the image at most 20 lines high
 }
 
 /* These choices are inspired by the material design system. Someone
@@ -198,7 +201,7 @@ html {
   background-color: var(--background-color);
   height: 100%;
   width: 100%;
-  line-height: 1.75rem;
+  line-height: var(--line-height);
   font-size: 13.5pt;
   scroll-padding-top: 40px;
 }
@@ -1901,11 +1904,35 @@ abbr {
 }
 
 .figure img {
-  width: 100%;
+  max-width: 100%;
+  max-height: var(--image-max-height);
+  transition: 0.3s;
+  cursor: pointer;
+  border-radius: 5px;
 }
 
-.mediaobject > img:hover, .mediaobject > img:active {
-  width: unset;
+.mediaobject {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mediaobject:active {
+  background-color: rgba(0,0,0,0.9);
+  top: 0;
+  left: 0;
+  z-index: 1;
+  position: fixed;
+  width: 100vw;
+  height: 100vh;
+}
+
+.mediaobject > img:active {
+  width: auto;
+  height: auto;
+  margin: auto;
+  max-height: 90%;
+  max-width: 90%;
 }
 
 /* ============================================================ */

--- a/res/docbook.js
+++ b/res/docbook.js
@@ -1,0 +1,138 @@
+window.onload = (event) => {
+    console.log('The page has fully loaded');
+    console.log("document.load", event, Date.now());
+    
+    var figContentMediaobj = document.querySelectorAll(".figure-contents > .mediaobject");
+    for (var ii = 0; ii < figContentMediaobj.length; ii++){
+	figContentMediaobj.item(ii).onclick = function() {
+	    if (this.style.zIndex == 0) {
+		this.style.zIndex = 1;
+		this.style.backgroundColor = 'rgba(0,0,0,0.9)';
+		this.style.top = 0;
+		this.style.left = 0;
+		this.style.position = 'fixed';
+		this.style.width = '100vw';
+		this.style.height = '100vh';
+		document.querySelector("body").style.overflow = "hidden";
+	    } else {
+		this.style.zIndex = 0;
+		this.style.backgroundColor = '#fff';
+		this.style.top = 'auto';
+		this.style.left = 'auto';
+		this.style.position = 'relative';
+		this.style.width = 'auto';
+		this.style.height = 'auto';
+		document.querySelector("body").style.overflow = "auto";
+	    }
+	}
+    }
+
+    var informafigs = document.querySelectorAll(".informalfigure");
+    for (var ii = 0; ii < informafigs.length; ii++){
+	informafigs.item(ii).onclick = function() {
+	    if (this.style.zIndex == 0) {
+		this.style.zIndex = 1;
+		this.style.backgroundColor = 'rgba(0,0,0,0.9)';
+		this.style.top = 0;
+		this.style.left = 0;
+		this.style.position = 'fixed';
+		this.style.width = '100vw';
+		this.style.height = '100vh';
+		this.style.justifyContent = 'center';
+		document.querySelector("body").style.overflow = "hidden";
+	    } else {
+		this.style.zIndex = 0;
+		this.style.backgroundColor = '#fff';
+		this.style.top = 'auto';
+		this.style.left = 'auto';
+		this.style.position = 'relative';
+		this.style.width = 'auto';
+		this.style.height = 'auto';
+		this.style.justifyContent = 'start';
+		document.querySelector("body").style.overflow = "auto";
+	    }
+	}
+    }
+
+    var inlinemediaobjs = document.querySelectorAll(".inlinemediaobject");
+    for (var ii = 0; ii < inlinemediaobjs.length; ii++){
+	inlinemediaobjs.item(ii).onclick = function() {
+	    if (this.style.zIndex == 0) {
+		this.style.zIndex = 1;
+		this.style.backgroundColor = 'rgba(0,0,0,0.9)';
+		this.style.top = 0;
+		this.style.left = 0;
+		this.style.position = 'fixed';
+		this.style.width = '100vw';
+		this.style.height = '100vh';
+		this.style.justifyContent = 'center';
+		this.style.alignItems = 'center';
+		this.style.display = 'flex';
+		document.querySelector("body").style.overflow = "hidden";
+	    } else {
+		this.style.zIndex = 0;
+		this.style.backgroundColor = '#fff';
+		this.style.top = 'auto';
+		this.style.left = 'auto';
+		this.style.position = 'relative';
+		this.style.width = 'auto';
+		this.style.height = 'auto';
+		this.style.alignItems = 'auto';
+		this.style.justifyContent = 'start';
+		this.style.display = 'block'
+		document.querySelector("body").style.overflow = "auto";
+	    }
+	}
+    }
+
+    var figContentsMediaObjImgs = document.querySelectorAll(".figure-contents > .mediaobject > .img");
+    for (var ii = 0; ii < figContentsMediaObjImgs.length; ii++){
+	figContentsMediaObjImgs.item(ii).onclick = function() {
+	    if (this.style.padding == '0em') {
+		console.log('selected');
+		this.style.padding = '0px';
+		this.style.maxWidth = '95%';
+		this.style.maxHeight = '95%';
+	    } else {
+		console.log('deselected');
+		this.style.padding = '0em';
+		this.style.maxWidth = '100%';
+		this.style.maxHeight = '31.5rem';
+	    }
+	}
+    }
+    
+    var informalfigImgs = document.querySelectorAll(".informalfigure > .img");
+    for (var ii = 0; ii < informalfigImgs.length; ii++){
+	informalfigImgs.item(ii).onclick = function() {
+	    if (this.style.padding == '0em') {
+		console.log('selected');
+		this.style.padding = '0px';
+		this.style.maxWidth = '95%';
+		this.style.maxHeight = '95%';
+	    } else {
+		console.log('deselected');
+		this.style.padding = '0em';
+		this.style.maxWidth = '70%';
+		this.style.maxHeight = '8.75rem';
+	    }
+	}
+    }
+
+    var inlinemediaobjImgs = document.querySelectorAll(".informalfigure > .img");
+    for (var ii = 0; ii < inlinemediaobjImgs.length; ii++){
+	inlinemediaobjImgs.item(ii).onclick = function() {
+	    if (this.style.padding == '0em') {
+		console.log('selected');
+		this.style.padding = '0px';
+		this.style.maxWidth = '95%';
+		this.style.maxHeight = '95%';
+	    } else {
+		console.log('deselected');
+		this.style.padding = '0em';
+		this.style.maxWidth = '100%';
+		this.style.maxHeight = '1.75rem';
+	    }
+	}
+    }
+}

--- a/res/styling.xsd
+++ b/res/styling.xsd
@@ -4,4 +4,5 @@
                 version="1.0">
   <xsl:param name="use.id.as.filename" select="'1'"/>
   <xsl:param name="html.stylesheet" select="'res/docbook.css'"/>
+  <xsl:param name="html.script" select="'res/docbook.js'"/>
 </xsl:stylesheet>

--- a/res/styling.xsd
+++ b/res/styling.xsd
@@ -3,8 +3,5 @@
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
                 version="1.0">
   <xsl:param name="use.id.as.filename" select="'1'"/>
-  <xsl:param name="admon.graphics" select="'1'"/>
-  <xsl:param name="admon.graphics.path"></xsl:param>
-  <xsl:param name="chunk.section.depth" select="0"></xsl:param>
   <xsl:param name="html.stylesheet" select="'res/docbook.css'"/>
 </xsl:stylesheet>


### PR DESCRIPTION
rescale `<figure>`s to 100% page width

all standalone images that should not be rescaled (e.g. those taller than wider) should be wrapped into `<informalfigure>` instead of `<figure>` (not done here).

user can view the image at its original size when either hovering or clicking on it.

@cme it's not sophisticated and there is quite some room for improvement. But would this point towards a solution you are comfortable with? (Especially since I have no HiDPI figures/display to try it.)