### PR TITLE
Fix some MIDI descriptions + add SELECT_ONLY_NEXT_PATTERN_CC_ABSOLUTE

### DIFF
--- a/manual.docbook
+++ b/manual.docbook
@@ -6522,9 +6522,12 @@ in the <link linkend="sect.main_toolbar.transport_control">Main Toolbar</link> a
 	       
            <listitem id="chpt.midi.actions.actions.select_next_pattern" xreflabel="SELECT_NEXT_PATTERN"><para>
              <emphasis role="bold">SELECT_NEXT_PATTERN</emphasis>:
-             switches to the pattern specified in <emphasis role="bold">Action Param</emphasis>.
+             selects the pattern specified in <emphasis role="bold">Action Param</emphasis>.
 
              <note>
+               <para>
+                 If Hydrogen is in <link linkend="chpt.song_editor.editor_modes.pattern_mode">Selected Pattern Mode</link>, playback will be switched to the selected pattern immediately. If it is, instead, in <link linkend="chpt.song_editor.editor_modes.stacked">Stacked Pattern Mode</link>, playback of the selected pattern will be toggled next time transport is loop again. In case the pattern was already playing, it will be stopped. If not, it will be started.
+               </para>
 	           <para>
 	             If Hydrogen is in <link linkend="chpt.song_editor.editor_modes.song_mode">Song Mode</link>, the command will have no effect.
                </para>
@@ -6533,35 +6536,36 @@ in the <link linkend="sect.main_toolbar.transport_control">Main Toolbar</link> a
 
            <listitem><para>
              <emphasis role="bold">SELECT_NEXT_PATTERN_CC_ABSOLUTE</emphasis>:
-             like <xref linkend="chpt.midi.actions.actions.select_next_pattern" /> but only take effect in <link linkend="chpt.song_editor.editor_modes.stacked">Stacked Pattern Mode</link>.
+             like <xref linkend="chpt.midi.actions.actions.select_next_pattern" /> but the pattern to be selected is determined by the value of the <abbrev>MIDI</abbrev> message.
            </para></listitem>
 
            <listitem><para>
              <emphasis role="bold">SELECT_NEXT_PATTERN_RELATIVE</emphasis>:
-             switches <emphasis role="bold">Action Param</emphasis> patterns forward.
-
-             <note>
-	           <para>
-                 This Action does only increment the pattern number and will only take effect if Hydrogen is in <link linkend="chpt.song_editor.editor_modes.stacked">Stacked Pattern Mode</link>.
-               </para>
-             </note>
+             like <xref linkend="chpt.midi.actions.actions.select_next_pattern" /> but the pattern to be selected is determined by the pattern number of the currently selected one plus the value specified in <emphasis role="bold">Action Param</emphasis>.
            </para></listitem>
 
-           <listitem><para>
+           <listitem id="chpt.midi.actions.actions.select_only_next_pattern" xreflabel="SELECT_ONLY_NEXT_PATTERN"><para>
              <emphasis role="bold">SELECT_ONLY_NEXT_PATTERN</emphasis>:
-             clears the list of patterns currently playing in <link linkend="chpt.song_editor.editor_modes.stacked">Stacked Pattern Mode</link> and adds the one specified in <emphasis role="bold">Action Param</emphasis>.
+             selects the pattern specified in <emphasis role="bold">Action Param</emphasis>.
+
+             <note>
+               <para>
+                 If Hydrogen is in <link linkend="chpt.song_editor.editor_modes.stacked">Stacked Pattern Mode</link>, only the selected pattern will be played back once the transport gets looped again. For <link linkend="chpt.song_editor.editor_modes.pattern_mode">Selected Pattern Mode</link> this action behaves as <xref linkend="chpt.midi.actions.actions.select_next_pattern" />.
+               </para>
+	           <para>
+	             If Hydrogen is in <link linkend="chpt.song_editor.editor_modes.song_mode">Song Mode</link>, the command will have no effect.
+               </para>
+             </note>
              <tip>
                <para>
                  By providing a number smaller than <option>0</option> or larger than the number of available patterns all playing patterns can be stopped at once without stopping playback itself.
                </para>
              </tip>
-             <note>
-	           <para> In <link
-                 linkend="chpt.song_editor.editor_modes.pattern_mode">Selected
-                 Pattern Mode</link> this action behaves like <xref linkend="chpt.midi.actions.actions.select_next_pattern"/>. If Hydrogen is in
-                 <link linkend="chpt.song_editor.editor_modes.song_mode">Song Mode</link>, the command will have no effect.
-               </para>
-             </note>
+           </para></listitem>
+
+           <listitem><para>
+             <emphasis role="bold">SELECT_ONLY_NEXT_PATTERN_CC_ABSOLUTE</emphasis>:
+             like <xref linkend="chpt.midi.actions.actions.select_only_next_pattern" /> but the pattern to be selected is determined by the value of the <abbrev>MIDI</abbrev> message.
            </para></listitem>
 
            <listitem id="chpt.midi.actions.actions.stop" xreflabel="STOP"><para>

--- a/manual.docbook
+++ b/manual.docbook
@@ -1530,11 +1530,10 @@ in the <link linkend="sect.main_toolbar.transport_control">Main Toolbar</link> a
 	      <listitem>
 	        <para>
 	          <emphasis role="bold">Use output note as input note</emphasis>:
-              specifies whether the output <abbrev>MIDI</abbrev> note of an instrument specified in the <link linkend="chpt.instrument_editor.midi_out_settings"><abbrev>MIDI</abbrev> Out Settings</link> of the Instrument Editor should be used to map the input as well.
-
+              if checked the instrument mapped to an incoming <abbrev>MIDI</abbrev> note is determined by its <link linkend="chpt.instrument_editor.midi_out_settings"><abbrev>MIDI</abbrev> Out Settings</link> in the Instrument Editor. Otherwise, the <link linkend="chpt.overview.midi_mapping_and_virtual_keyboard">default <abbrev>MIDI mapping</abbrev></link> (based on the instrument order in the <link linkend="chpt.pattern_editor">Pattern Editor</link>) will be used.
               <note>
 	            <para>
-	              If this option is unchecked, only the currently selected instrument will used to play back the received <abbrev>MIDI</abbrev> notes.
+	              This option only takes effect if <emphasis role="bold">Input mode</emphasis> in the <link linkend="sect.main_menu.options">Options</link> tab of the Main Menu is set to <option>Drumkit</option>.
                 </para>
               </note>
             </para>


### PR DESCRIPTION
- SELECT_ONLY_NEXT_PATTERN_CC_ABSOLUTE (introduced in https://github.com/hydrogen-music/hydrogen/pull/1640) was added to the MIDI API and the remaining SELECT_*_PATTERN descriptions were updated
- "Use output note as input note" explanation was partially wrong and fix